### PR TITLE
DEV-7921 Image replace operation remains enabled when document is out of sync

### DIFF
--- a/packages/dita-example-sx-integration/src/install.js
+++ b/packages/dita-example-sx-integration/src/install.js
@@ -1,6 +1,20 @@
 import addTransform from 'fontoxml-operations/src/addTransform.js';
 
 export default function install() {
+	addTransform(
+		'removeImageValue',
+		function (stepData) {
+			// After checking the state, we go to the next operation to select the reference from image url
+			return stepData;
+		},
+		function removeImageValue(stepData) {
+			// When we get the operation state, we don't still want to select the image, we
+			// only want to check if document is editable
+			stepData.selectedImageId = null;
+			return stepData;
+		}
+	);
+
 	addTransform('setReferenceForUrl', function setReferenceForUrl(stepData) {
 		stepData.reference = stepData.url;
 		return stepData;

--- a/packages/dita-example-sx-integration/src/install.js
+++ b/packages/dita-example-sx-integration/src/install.js
@@ -2,12 +2,12 @@ import addTransform from 'fontoxml-operations/src/addTransform.js';
 
 export default function install() {
 	addTransform(
-		'removeImageValue',
+		'unsetSelectedImageIdForGetState',
 		function (stepData) {
 			// After checking the state, we go to the next operation to select the reference from image url
 			return stepData;
 		},
-		function removeImageValue(stepData) {
+		function unsetSelectedImageIdForGetState(stepData) {
 			// When we get the operation state, we don't still want to select the image, we
 			// only want to check if document is editable
 			stepData.selectedImageId = null;

--- a/packages/dita-example-sx-integration/src/operations.json
+++ b/packages/dita-example-sx-integration/src/operations.json
@@ -140,7 +140,7 @@
 				}
 			},
 			{
-				"type": "transform/removeImageValue",
+				"type": "transform/unsetSelectedImageIdForGetState",
 				"data": {
 					"selectedImageId": "{{selectedImageId}}"
 				}

--- a/packages/dita-example-sx-integration/src/operations.json
+++ b/packages/dita-example-sx-integration/src/operations.json
@@ -140,6 +140,12 @@
 				}
 			},
 			{
+				"type": "transform/removeImageValue",
+				"data": {
+					"selectedImageId": "{{selectedImageId}}"
+				}
+			},
+			{
 				"type": "transform/setReferenceForUrl",
 				"data": {
 					"url": "{{selectedImageId}}"


### PR DESCRIPTION
The error was that image was selected before checking the document state.