### PR TITLE
DEV-12834 Update CVK options for 7.17

### DIFF
--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.js
@@ -311,7 +311,7 @@ export default function configureSxModule(sxModule) {
 				implicit: 'inline',
 			},
 			referenceQuery: '@href',
-			isPermanentId: true
+			isPermanentId: true,
 		}
 	);
 

--- a/packages/dita-example-sx-modules-xsd-ui-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-ui-domain/src/configureSxModule.js
@@ -15,8 +15,8 @@ export default function configureSxModule(sxModule) {
 	//     user interface domain, a special set of DITA elements designed to document user interface tasks,
 	//     concepts and reference information. Category: User interface elements
 	configureAsInlineFrame(sxModule, 'self::menucascade', t('menu cascade'), {
-		isIgnoredForNavigation: false,
-		defaultTextContainer: 'uicontrol'
+		defaultTextContainer: 'uicontrol',
+		isIgnoredForNavigation: false
 	});
 
 	// screen

--- a/packages/dita-example-sx-modules-xsd-ui-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-ui-domain/src/configureSxModule.js
@@ -15,8 +15,13 @@ export default function configureSxModule(sxModule) {
 	//     user interface domain, a special set of DITA elements designed to document user interface tasks,
 	//     concepts and reference information. Category: User interface elements
 	configureAsInlineFrame(sxModule, 'self::menucascade', t('menu cascade'), {
-		defaultTextContainer: 'uicontrol',
-		isIgnoredForNavigation: false
+		defaultTextContainer: {
+			localName: 'uicontrol',
+			namespaceURI: null,
+			insert: 'always',
+			implicit: 'inline',
+		},
+		isIgnoredForNavigation: false,
 	});
 
 	// screen


### PR DESCRIPTION
Remove use of private API `ignoredForNavigationNextToSelector` and replace it with setting the public `isIgnoredForNavigation` to `false`, which (in the upcoming release) will have the same effect of allowing cursor positions directly next to the `defaultTextContainer`.

To prevent the new enter and normalization behavior for inline `defaultTextContainer` elements, update these to the new syntax to specify `implicit: 'inline'`.