### PR TITLE
Dev 13525 xquerytemplates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@
 # It is recommended that you commit these files to your version control. To this end, please remove the following line
 # from this file:
 /platform/
-/platform-linked/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 # It is recommended that you commit these files to your version control. To this end, please remove the following line
 # from this file:
 /platform/
+/platform-linked/

--- a/config/configuration.js
+++ b/config/configuration.js
@@ -1,4 +1,5 @@
 import configurationManager from 'fontoxml-configuration/src/configurationManager.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 configurationManager.set('paragraph-node-name-for-pasting', 'p');
 
@@ -15,7 +16,7 @@ configurationManager.set('spell-checker-configuration', {
 
 configurationManager.set('unique-id-configurations', [
 	{
-		selector: 'self::*',
+		selector: xq`self::*`,
 		namespaceURI: null,
 		localName: 'id'
 	}

--- a/packages/dita-example-masthead/src/DitaExampleMasthead.jsx
+++ b/packages/dita-example-masthead/src/DitaExampleMasthead.jsx
@@ -18,6 +18,7 @@ import StartToolbar from './toolbars/StartToolbar.jsx';
 import StructureToolbar from './toolbars/StructureToolbar.jsx';
 import TaskToolbar from './toolbars/TaskToolbar.jsx';
 import ToolsToolbar from './toolbars/ToolsToolbar.jsx';
+import xq from 'fontoxml-selectors/src/xq';
 
 const labels = {
 	matching: 'Matching question',
@@ -44,21 +45,21 @@ const tabs = result => [
 		id: 'table',
 		label: 'Table',
 		isVisibleTabQuery:
-			'ancestor-or-self::*[self::table or self::simpletable or self::dl or self::parml or self::properties or self::choicetable]',
+			xq`ancestor-or-self::*[self::table or self::simpletable or self::dl or self::parml or self::properties or self::choicetable]`,
 		isHighlightedTab: true,
 		content: <TableToolbar />
 	},
 	{
 		id: 'task',
 		label: 'Task',
-		isVisibleTabQuery: 'ancestor-or-self::task',
+		isVisibleTabQuery: xq`ancestor-or-self::task`,
 		isHighlightedTab: true,
 		content: <TaskToolbar />
 	},
 	{
 		id: 'glossary',
 		label: 'Glossary',
-		isVisibleTabQuery: 'ancestor-or-self::glossgroup',
+		isVisibleTabQuery: xq`ancestor-or-self::glossgroup`,
 		isHighlightedTab: true,
 		content: <GlossaryToolbar />
 	},
@@ -66,7 +67,7 @@ const tabs = result => [
 		id: 'learning',
 		label: 'Learning & training',
 		isVisibleTabQuery:
-			'ancestor-or-self::*[self::learningAssessment or self::learningPlan or self::learningOverview or self::learningSummary or self::learningContent]',
+			xq`ancestor-or-self::*[self::learningAssessment or self::learningPlan or self::learningOverview or self::learningSummary or self::learningContent]`,
 		isHighlightedTab: true,
 		content: <LearningTrainingToolbar />
 	},
@@ -74,7 +75,7 @@ const tabs = result => [
 		id: 'question',
 		label: getQuestionLabel(result),
 		isVisibleTabQuery:
-			'ancestor-or-self::*[self::lcMatching2 or self::lcMultipleSelect2 or self::lcOpenQuestion2 or self::lcSequencing2 or self::lcSingleSelect2 or self::lcTrueFalse2]',
+			xq`ancestor-or-self::*[self::lcMatching2 or self::lcMultipleSelect2 or self::lcOpenQuestion2 or self::lcSequencing2 or self::lcSingleSelect2 or self::lcTrueFalse2]`,
 		isHighlightedTab: true,
 		content: <QuestionToolbar />
 	},
@@ -86,12 +87,12 @@ export default function DitaExampleMasthead() {
 	return (
 		<FxBooleanXPathQueryByNameFromSelection
 			xpathQueryByName={{
-				matching: 'ancestor-or-self::lcMatching2',
-				multipleSelect: 'ancestor-or-self::lcMultipleSelect2',
-				openQuestion: 'ancestor-or-self::lcOpenQuestion2',
-				sequencing: 'ancestor-or-self::lcSequencing2',
-				singleSelect: 'ancestor-or-self::lcSingleSelect2',
-				trueFalse: 'ancestor-or-self::lcTrueFalse2'
+				matching: xq`ancestor-or-self::lcMatching2`,
+				multipleSelect: xq`ancestor-or-self::lcMultipleSelect2`,
+				openQuestion: xq`ancestor-or-self::lcOpenQuestion2`,
+				sequencing: xq`ancestor-or-self::lcSequencing2`,
+				singleSelect: xq`ancestor-or-self::lcSingleSelect2`,
+				trueFalse: xq`ancestor-or-self::lcTrueFalse2`
 			}}
 		>
 			{({ xpathQueryResultByName }) => (

--- a/packages/dita-example-masthead/src/menus/InsertTopicMenu.jsx
+++ b/packages/dita-example-masthead/src/menus/InsertTopicMenu.jsx
@@ -10,6 +10,7 @@ import readOnlyBlueprint from 'fontoxml-blueprints/src/readOnlyBlueprint.js';
 import selectionManager from 'fontoxml-selection/src/selectionManager.js';
 import useXPath from 'fontoxml-fx/src/useXPath.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 import { Drop, Menu, MenuGroup, MenuItemWithDrop } from 'fds/components';
 

--- a/packages/dita-example-masthead/src/menus/InsertTopicMenu.jsx
+++ b/packages/dita-example-masthead/src/menus/InsertTopicMenu.jsx
@@ -151,7 +151,7 @@ function createTopicSubMenu(refNodeId) {
 }
 
 const InsertTopicMenu = () => {
-	const selectionNode = useXPath('fonto:selection-common-ancestor()');
+	const selectionNode = useXPath(xq`fonto:selection-common-ancestor()`);
 	const [refNodeId, setRefNodeId] = useState(null);
 	const [refElementName, setRefElementName] = useState('');
 	const [isContainerOrPlaceholder, setIsContainerOrPlaceholder] = useState(false);
@@ -178,7 +178,7 @@ const InsertTopicMenu = () => {
 			if (
 				!documentElement ||
 				!evaluateXPathToBoolean(
-					'fonto:dita-class(., "map/map")',
+					xq`fonto:dita-class(., "map/map")`,
 					documentElement,
 					readOnlyBlueprint
 				)
@@ -195,7 +195,7 @@ const InsertTopicMenu = () => {
 				// Check if ancestor is itself a topicref or map (then use that)
 				if (
 					evaluateXPathToBoolean(
-						'fonto:dita-class(., "map/topicref") or fonto:dita-class(., "map/map")',
+						xq`fonto:dita-class(., "map/topicref") or fonto:dita-class(., "map/map")`,
 						ancestor,
 						readOnlyBlueprint
 					)
@@ -239,10 +239,10 @@ const InsertTopicMenu = () => {
 		setRefNodeId(newRefNodeId);
 		const newRefNode = documentsManager.getNodeById(newRefNodeId);
 		setRefElementName(
-			newRefNode ? evaluateXPathToString('./name()', newRefNode, readOnlyBlueprint) : ''
+			newRefNode ? evaluateXPathToString(xq`./name()`, newRefNode, readOnlyBlueprint) : ''
 		);
 		setIsContainerOrPlaceholder(
-			newRefNode ? evaluateXPathToBoolean('not(@href)', newRefNode, readOnlyBlueprint) : ''
+			newRefNode ? evaluateXPathToBoolean(xq`not(@href)`, newRefNode, readOnlyBlueprint) : ''
 		);
 	}, [selectionNode]);
 

--- a/packages/dita-example-masthead/src/toolbars/LearningTrainingToolbar.jsx
+++ b/packages/dita-example-masthead/src/toolbars/LearningTrainingToolbar.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import FxBooleanXPathQueryByNameFromSelection from 'fontoxml-fx/src/FxBooleanXPathQueryByNameFromSelection.jsx';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton.jsx';
 import FxOperationMenuItem from 'fontoxml-fx/src/FxOperationMenuItem.jsx';
+import xq from 'fontoxml-selectors/src/xq';
 
 import {
 	ButtonWithDrop,
@@ -111,11 +112,11 @@ const renderNeedsAnalysisDrop = () => (
 const LearningTrainingToolbar = () => (
 	<FxBooleanXPathQueryByNameFromSelection
 		xpathQueryByName={{
-			learningAssessment: 'ancestor-or-self::learningAssessment',
-			learningContent: 'ancestor-or-self::learningContent',
-			learningOverview: 'ancestor-or-self::learningOverview',
-			learningSummary: 'ancestor-or-self::learningSummary',
-			learningPlan: 'ancestor-or-self::learningPlan'
+			learningAssessment: xq`ancestor-or-self::learningAssessment`,
+			learningContent: xq`ancestor-or-self::learningContent`,
+			learningOverview: xq`ancestor-or-self::learningOverview`,
+			learningSummary: xq`ancestor-or-self::learningSummary`,
+			learningPlan: xq`ancestor-or-self::learningPlan`
 		}}
 	>
 		{({ xpathQueryResultByName }) => (

--- a/packages/dita-example-masthead/src/toolbars/QuestionToolbar.jsx
+++ b/packages/dita-example-masthead/src/toolbars/QuestionToolbar.jsx
@@ -11,16 +11,17 @@ import {
 import FxBooleanXPathQueryByNameFromSelection from 'fontoxml-fx/src/FxBooleanXPathQueryByNameFromSelection.jsx';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton.jsx';
 import FxOperationMenuItem from 'fontoxml-fx/src/FxOperationMenuItem.jsx';
+import xq from 'fontoxml-selectors/src/xq';
 
 const QuestionToolbar = () => (
 	<FxBooleanXPathQueryByNameFromSelection
 		xpathQueryByName={{
-			matching: 'ancestor-or-self::lcMatching2',
+			matching: xq`ancestor-or-self::lcMatching2`,
 			multipleOrSingleSelect:
-				'ancestor-or-self::*[self::lcMultipleSelect2 or self::lcSingleSelect2]',
-			openQuestion: 'ancestor-or-self::lcOpenQuestion2',
-			sequencing: 'ancestor-or-self::lcSequencing2',
-			trueFalse: 'ancestor-or-self::lcTrueFalse2'
+				xq`ancestor-or-self::*[self::lcMultipleSelect2 or self::lcSingleSelect2]`,
+			openQuestion: xq`ancestor-or-self::lcOpenQuestion2`,
+			sequencing: xq`ancestor-or-self::lcSequencing2`,
+			trueFalse: xq`ancestor-or-self::lcTrueFalse2`
 		}}
 	>
 		{({ xpathQueryResultByName }) => (

--- a/packages/dita-example-structure-view/src/configureSxModule.js
+++ b/packages/dita-example-structure-view/src/configureSxModule.js
@@ -3,6 +3,7 @@ import configureContextualOperations from 'fontoxml-families/src/configureContex
 import configureProperties from 'fontoxml-families/src/configureProperties.js';
 import registerNodeStatus from 'fontoxml-families/src/registerNodeStatus.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 // Operation names to create a child topic, either from template or reusing an existing topic;
 const INSERT_TOPICREF_OPERATION_NAMES = [
@@ -44,27 +45,27 @@ export default function configureSxModule(sxModule) {
 	//
 	// See also:
 	//   https://documentation.fontoxml.com/latest/add-and-configure-document-outline-e4f7c8b3a049
-	configureAsStructureViewItem(sxModule, 'fonto:dita-class(., "map/map")', {
+	configureAsStructureViewItem(sxModule, xq`fonto:dita-class(., "map/map")`, {
 		icon: 'folder-open-o',
-		recursionQuery: '()'
+		recursionQuery: xq`()`
 	});
-	configureAsStructureViewItem(sxModule, 'fonto:dita-class(., "map/topicref") and not(@href)', {
+	configureAsStructureViewItem(sxModule, xq`fonto:dita-class(., "map/topicref") and not(@href)`, {
 		icon: 'folder-open-o',
-		recursionQuery: '()'
+		recursionQuery: xq`()`
 	});
-	configureAsStructureViewItem(sxModule, 'self::topicgroup', {
+	configureAsStructureViewItem(sxModule, xq`self::topicgroup`, {
 		icon: 'folder-open-o',
-		recursionQuery: '()'
+		recursionQuery: xq`()`
 	});
-	configureAsStructureViewItem(sxModule, 'self::topichead', {
+	configureAsStructureViewItem(sxModule, xq`self::topichead`, {
 		icon: 'folder-open-o',
-		recursionQuery: '()'
+		recursionQuery: xq`()`
 	});
-	configureAsStructureViewItem(sxModule, 'self::glossgroup', {
+	configureAsStructureViewItem(sxModule, xq`self::glossgroup`, {
 		icon: 'file-text-o',
-		recursionQuery: 'glossentry'
+		recursionQuery: xq`glossentry`
 	});
-	configureAsStructureViewItem(sxModule, 'fonto:dita-class(., "topic/topic")', {
+	configureAsStructureViewItem(sxModule, xq`fonto:dita-class(., "topic/topic")`, {
 		icon: 'file-text-o'
 	});
 
@@ -79,13 +80,13 @@ export default function configureSxModule(sxModule) {
 	//   https://documentation.fontoxml.com/latest/contextualoperation-9316242986ab#properties
 	configureContextualOperations(
 		sxModule,
-		'fonto:dita-class(., "map/map")',
+		xq`fonto:dita-class(., "map/map")`,
 		formatContextualOperationListWithGroups([INSERT_TOPICREF_OPERATION_NAMES]),
 		-3
 	);
 	configureContextualOperations(
 		sxModule,
-		'fonto:dita-class(., "map/topicref")',
+		xq`fonto:dita-class(., "map/topicref")`,
 		formatContextualOperationListWithGroups([
 			INSERT_TOPICREF_OPERATION_NAMES,
 			...MOVE_TOPICREF_OPERATION_NAMES
@@ -94,7 +95,7 @@ export default function configureSxModule(sxModule) {
 	);
 	configureContextualOperations(
 		sxModule,
-		'self::mapref',
+		xq`self::mapref`,
 		formatContextualOperationListWithGroups(MOVE_TOPICREF_OPERATION_NAMES),
 		-2
 	);
@@ -125,8 +126,8 @@ export default function configureSxModule(sxModule) {
 			backgroundColor: 'state-message-success-color'
 		}
 	});
-	configureProperties(sxModule, 'self::*', {
-		statusQuery: `
+	configureProperties(sxModule, xq`self::*`, {
+		statusQuery: xq`
 			(
 				if (./prolog/metadata/data/@status="changed")
 					then "revised"

--- a/packages/dita-example-sx-integration/src/configureSxModule.js
+++ b/packages/dita-example-sx-integration/src/configureSxModule.js
@@ -4,6 +4,7 @@ import configureProperties from 'fontoxml-families/src/configureProperties.js';
 import createLabelQueryWidget from 'fontoxml-families/src/createLabelQueryWidget.js';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import namespaceManager from 'fontoxml-dom-namespaces/src/namespaceManager.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 import configureHazardsymbolWithoutPermanentId from 'dita-example-sx-modules-xsd-hazard-domain/src/configureHazardsymbolWithoutPermanentId.js';
 import configureImageWithoutPermanentId from 'dita-example-sx-modules-xsd-common-element-mod/src/configureImageWithoutPermanentId.js';
@@ -22,7 +23,7 @@ export default function configureSxModule(sxModule) {
 	//
 	// Make sure you've tested your application without this configuration, in order to more easily detect elements
 	// that are lacking configuration.
-	configureAsRemoved(sxModule, 'self::*', undefined, {
+	configureAsRemoved(sxModule, xq`self::*`, undefined, {
 		priority: -2
 	});
 
@@ -30,7 +31,7 @@ export default function configureSxModule(sxModule) {
 	// configureAsConref family will itself determine wether an XML tag indeed has all the required conref
 	// information. Fonto will then render the note in the location of the conref, regardless of which document
 	// actually contains the conreffed content.
-	configureAsConref(sxModule, 'self::note', 'reused note', {
+	configureAsConref(sxModule, xq`self::note`, 'reused note', {
 		contextualOperations: [],
 		popoverData: {
 			editOperationName: 'contextual-edit-note[@conref]'
@@ -42,9 +43,9 @@ export default function configureSxModule(sxModule) {
 	// Needed for bookmap implementation
 	configureProperties(
 		sxModule,
-		'self::*[fonto:dita-class(., "topic/topic")][not(parent::*[fonto:dita-class(., "topic/topic")])]',
+		xq`self::*[fonto:dita-class(., "topic/topic")][not(parent::*[fonto:dita-class(., "topic/topic")])]`,
 		{
-			titleQuery: `
+			titleQuery: xq`
 			let $refNodeName := fonto:hierarchy-source-node(fonto:current-hierarchy-node-id())/name(),
 			$title := ./*[fonto:dita-class(., "topic/title")]//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()
 
@@ -52,9 +53,11 @@ export default function configureSxModule(sxModule) {
 				if(not($refNodeName) or not(bookmap:retrieve-element-label($refNodeName)))
 				then $title
 				else string-join(upper-case(bookmap:retrieve-element-label($refNodeName)) || ": " || $title)`,
-			blockHeaderLeft: [
-				createLabelQueryWidget('""', {
-					prefixQuery: `
+			blockHeaderLeft: 
+			// TODO: fix createLabelQueryWidget
+			[
+				createLabelQueryWidget(`""`, {
+					prefixQuery: xq`
 					let $refNodeName := fonto:hierarchy-source-node(fonto:current-hierarchy-node-id())/name()
 
 					return

--- a/packages/dita-example-sx-integration/src/configureSxModule.js
+++ b/packages/dita-example-sx-integration/src/configureSxModule.js
@@ -54,10 +54,10 @@ export default function configureSxModule(sxModule) {
 				then $title
 				else string-join(upper-case(bookmap:retrieve-element-label($refNodeName)) || ": " || $title)`,
 			blockHeaderLeft: 
-			// TODO: fix createLabelQueryWidget
+			// TODO: Upgrade the createLabelQueryWidget when it accepts XQuery template tags in 7.18
 			[
 				createLabelQueryWidget(`""`, {
-					prefixQuery: xq`
+					prefixQuery: `
 					let $refNodeName := fonto:hierarchy-source-node(fonto:current-hierarchy-node-id())/name()
 
 					return

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-assessment-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-assessment-mod/src/configureSxModule.js
@@ -6,6 +6,7 @@ import configureContextualOperations from 'fontoxml-families/src/configureContex
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// learningAssessment
@@ -13,14 +14,14 @@ export default function configureSxModule(sxModule) {
 	//     recollection, and stimulate reinforcement of the learning content, and can be presented before the
 	//     content as a pre-assessment or as a post-assessment test. The interactions use a sub-set of the
 	//     Question-Test Interoperability (QTI) specification, implemented as a DITA domain specialization.
-	configureAsSheetFrame(sxModule, 'self::learningAssessment', t('learning assessment'), {
+	configureAsSheetFrame(sxModule, xq`self::learningAssessment`, t('learning assessment'), {
 		defaultTextContainer: 'learningAssessmentbody',
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -29,30 +30,30 @@ export default function configureSxModule(sxModule) {
 	// learningAssessment nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::learningAssessment and ancestor::*[fonto:dita-class(., "topic/topic")]',
+		xq`self::learningAssessment and ancestor::*[fonto:dita-class(., "topic/topic")]`,
 		undefined,
 		{
 			defaultTextContainer: 'learningAssessmentbody',
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in learningAssessment
-	configureAsTitleFrame(sxModule, 'self::title[parent::learningAssessment]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::learningAssessment]`, undefined, {
 		fontVariation: 'document-title'
 	});
 
 	// learningAssessmentbody
 	//     The <learningAssessmentbody> element is the main body-level element in a learningAssessment topic.
-	configureAsStructure(sxModule, 'self::learningAssessmentbody', t('body'), {
+	configureAsStructure(sxModule, xq`self::learningAssessmentbody`, t('body'), {
 		defaultTextContainer: 'section',
 		isIgnoredForNavigation: false,
 		isRemovableIfEmpty: false
 	});
 
 	// section in learningAssessmentbody
-	configureContextualOperations(sxModule, 'self::section[parent::learningAssessmentbody]', [
+	configureContextualOperations(sxModule, xq`self::section[parent::learningAssessmentbody]`, [
 		{ name: ':section-insert-title' },
 		{ name: ':contextual-delete-section' }
 	]);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.js
@@ -9,18 +9,19 @@ import createIconWidget from 'fontoxml-families/src/createIconWidget.js';
 import createLabelQueryWidget from 'fontoxml-families/src/createLabelQueryWidget.js';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// lcAudience
 	//     The <lcAudience> describes characteristics of the learners who take the instruction.
-	configureAsFrame(sxModule, 'self::lcAudience', t('audience'), {
+	configureAsFrame(sxModule, xq`self::lcAudience`, t('audience'), {
 		contextualOperations: [
 			{ name: ':lcAudience-insert-title' },
 			{ name: ':contextual-delete-lcAudience' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the audience'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -29,21 +30,21 @@ export default function configureSxModule(sxModule) {
 	//     The <lcChallenge> refers to what it is that you want the student to practice. For example, if you're
 	//     studying network diagrams, and challenge might be "see if you can put this network into its proper
 	//     sequence" or "see if you understand this network flow".
-	configureAsFrame(sxModule, 'self::lcChallenge', t('challenge'), {
+	configureAsFrame(sxModule, xq`self::lcChallenge`, t('challenge'), {
 		contextualOperations: [
 			{ name: ':lcChallenge-insert-title' },
 			{ name: ':contextual-delete-lcChallenge' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the challenge'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcDuration
 	//     The <lcDuration> provides an estimated duration for the learning activity.
-	configureAsFrame(sxModule, 'self::lcDuration', t('duration'), {
+	configureAsFrame(sxModule, xq`self::lcDuration`, t('duration'), {
 		contextualOperations: [
 			{ name: ':lcDuration-insert-title' },
 			{ name: ':lcDuration-insert-lcTime' },
@@ -51,21 +52,21 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcInstruction
 	//     The <lcInstruction> describes the specifics of a learning activity.
-	configureAsFrame(sxModule, 'self::lcInstruction', t('instruction'), {
+	configureAsFrame(sxModule, xq`self::lcInstruction`, t('instruction'), {
 		contextualOperations: [
 			{ name: ':lcInstruction-insert-title' },
 			{ name: ':contextual-delete-lcInstruction' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the instruction'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -74,7 +75,7 @@ export default function configureSxModule(sxModule) {
 	//     The <lcInteraction> is a wrapper element for all the interactions of the assessment. The
 	//     interactions themselves are based on a basic set of assessment types implemented as a DITA domain
 	//     specialization.
-	configureAsStructure(sxModule, 'self::lcInteraction', t('interaction'), {
+	configureAsStructure(sxModule, xq`self::lcInteraction`, t('interaction'), {
 		isAutoremovableIfEmpty: true
 	});
 
@@ -82,46 +83,46 @@ export default function configureSxModule(sxModule) {
 	//     The <lcIntro> provides a detailed introduction and description of the content to be delivered, in
 	//     cases where the <shortdesc> is not adequate to fully describe the content. It may also include
 	//     instructor notes.
-	configureAsFrame(sxModule, 'self::lcIntro', t('intro'), {
+	configureAsFrame(sxModule, xq`self::lcIntro`, t('intro'), {
 		contextualOperations: [
 			{ name: ':lcIntro-insert-title' },
 			{ name: ':contextual-delete-lcIntro' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the intro'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcNextSteps
 	//     The <lcNextSteps> suggests next steps to reinforce the knowledge learned.
-	configureAsFrame(sxModule, 'self::lcNextSteps', t('next steps'), {
+	configureAsFrame(sxModule, xq`self::lcNextSteps`, t('next steps'), {
 		contextualOperations: [
 			{ name: ':lcNextSteps-insert-title' },
 			{ name: ':contextual-delete-lcNextSteps' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the next steps'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcObjective
 	//     The <lcObjective> describes a single learning objective.
-	configureAsBlock(sxModule, 'self::lcObjective', t('objective'), {
+	configureAsBlock(sxModule, xq`self::lcObjective`, t('objective'), {
 		contextualOperations: [
 			{ name: ':contextual-insert-lcObjective--above' },
 			{ name: ':contextual-insert-lcObjective--below' }
 		],
 		emptyElementPlaceholderText: t('type the objective'),
-		blockBefore: [createLabelQueryWidget('"\u25cf"')]
+		blockBefore: [createLabelQueryWidget(xq`"\u25cf"`)]
 	});
 
 	// lcObjectives
 	//     The <lcObjectives> lists or describes the learning goals.
-	configureAsFrame(sxModule, 'self::lcObjectives', t('objectives'), {
+	configureAsFrame(sxModule, xq`self::lcObjectives`, t('objectives'), {
 		contextualOperations: [
 			{ name: ':lcObjectives-insert-title' },
 			{ name: ':lcObjectives-insert-lcObjectivesStem' },
@@ -134,21 +135,21 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'lcObjectivesStem',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcObjectivesGroup
 	//     The <lcObjectivesGroup> contains a list of one or more learning objectives.
-	configureAsGroup(sxModule, 'self::lcObjectivesGroup', t('group'), {
+	configureAsGroup(sxModule, xq`self::lcObjectivesGroup`, t('group'), {
 		defaultTextContainer: 'objective',
 		expression: 'compact'
 	});
 
 	// lcObjectivesStem
 	//     The <lcObjectivesStem> provides a leading sentence to introduce a list of learning objectives.
-	configureAsFrameWithBlock(sxModule, 'self::lcObjectivesStem', t('stem'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcObjectivesStem`, t('stem'), {
 		emptyElementPlaceholderText: t('type the objectives stem'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -156,14 +157,14 @@ export default function configureSxModule(sxModule) {
 	// lcPrereqs
 	//     The <lcPrereqs> describes the knowledge, experience, or other prerequisites needed to complete the
 	//     content.
-	configureAsFrame(sxModule, 'self::lcPrereqs', t('prerequisites'), {
+	configureAsFrame(sxModule, xq`self::lcPrereqs`, t('prerequisites'), {
 		contextualOperations: [
 			{ name: ':lcPrereqs-insert-title' },
 			{ name: ':contextual-delete-lcPrereqs' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the prerequisites'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -171,28 +172,28 @@ export default function configureSxModule(sxModule) {
 	// lcResources
 	//     The <lcResources> provides a list of related resources and information about them, such as related
 	//     articles or samples on the web.
-	configureAsFrame(sxModule, 'self::lcResources', t('resources'), {
+	configureAsFrame(sxModule, xq`self::lcResources`, t('resources'), {
 		contextualOperations: [
 			{ name: ':lcResources-insert-title' },
 			{ name: ':contextual-delete-lcResources' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the resources'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcReview
 	//     The <lcReview> provides a review of the main points.
-	configureAsFrame(sxModule, 'self::lcReview', t('review'), {
+	configureAsFrame(sxModule, xq`self::lcReview`, t('review'), {
 		contextualOperations: [
 			{ name: ':lcReview-insert-title' },
 			{ name: ':contextual-delete-lcReview' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the review'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -200,24 +201,24 @@ export default function configureSxModule(sxModule) {
 	// lcSummary
 	//     The <lcSummary> provides a textual summary that describes the main learning goals and lessons
 	//     learned.
-	configureAsFrame(sxModule, 'self::lcSummary', t('summary'), {
+	configureAsFrame(sxModule, xq`self::lcSummary`, t('summary'), {
 		contextualOperations: [
 			{ name: ':lcSummary-insert-title' },
 			{ name: ':contextual-delete-lcSummary' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the summary'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcTime
 	//     The <lcTime> specifies the time expected to complete an activity.
-	configureAsFrameWithBlock(sxModule, 'self::lcTime', t('time'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcTime`, t('time'), {
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockHeaderRight: [
-			createLabelQueryWidget('./@value', {
+			createLabelQueryWidget(xq`./@value`, {
 				inline: true
 			}),
 			createIconWidget('clock-o', {
@@ -231,12 +232,12 @@ export default function configureSxModule(sxModule) {
 	//     The learningBase topic type is not used to deliver any actual learning content, but instead provides
 	//     a set of common elements for use in the other more specific learning content types:
 	//     learningOverview,learningContent, learningSummary, learningAssessment, and learningPlan.
-	configureAsRemoved(sxModule, 'self::learningBase', t('learning base'));
+	configureAsRemoved(sxModule, xq`self::learningBase`, t('learning base'));
 
 	// learningBasebody
 	//     The <learningBasebody> element is the main body-level element in a learningBase topic. The
 	//     learningBase topic provides a set of base elements for use in the other specialized learning types.
 	//     It is not generally intended for creating actual content. As such, each of the body sections in
 	//     learningBase are optional.
-	configureAsRemoved(sxModule, 'self::learningBasebody', t('learningBasebody'));
+	configureAsRemoved(sxModule, xq`self::learningBasebody`, t('learningBasebody'));
 }

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.js
@@ -216,10 +216,11 @@ export default function configureSxModule(sxModule) {
 
 	// lcTime
 	//     The <lcTime> specifies the time expected to complete an activity.
+	// TODO: Upgrade the createLabelQueryWidget when it accepts XQuery template tags in 7.18
 	configureAsFrameWithBlock(sxModule, xq`self::lcTime`, t('time'), {
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockHeaderRight: [
-			createLabelQueryWidget(xq`./@value`, {
+			createLabelQueryWidget(`./@value`, {
 				inline: true
 			}),
 			createIconWidget('clock-o', {

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.js
@@ -111,13 +111,14 @@ export default function configureSxModule(sxModule) {
 
 	// lcObjective
 	//     The <lcObjective> describes a single learning objective.
+	// TODO: Upgrade the createLabelQueryWidget when it accepts XQuery template tags in 7.18
 	configureAsBlock(sxModule, xq`self::lcObjective`, t('objective'), {
 		contextualOperations: [
 			{ name: ':contextual-insert-lcObjective--above' },
 			{ name: ':contextual-insert-lcObjective--below' }
 		],
 		emptyElementPlaceholderText: t('type the objective'),
-		blockBefore: [createLabelQueryWidget(xq`"\u25cf"`)]
+		blockBefore: [createLabelQueryWidget(`"\u25cf"`)]
 	});
 
 	// lcObjectives

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-content-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-content-mod/src/configureSxModule.js
@@ -6,6 +6,7 @@ import configureContextualOperations from 'fontoxml-families/src/configureContex
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// learningContent
@@ -14,14 +15,14 @@ export default function configureSxModule(sxModule) {
 	//     supports specific objectives declared in the Learning Overview topic type. A Learning Content topic
 	//     comprises a set of self-contained content about a single terminal learning objective supported by
 	//     zero or more enabling learning objectives.
-	configureAsSheetFrame(sxModule, 'self::learningContent', t('learning content'), {
+	configureAsSheetFrame(sxModule, xq`self::learningContent`, t('learning content'), {
 		defaultTextContainer: 'learningContentbody',
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -30,30 +31,30 @@ export default function configureSxModule(sxModule) {
 	// learningContent nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::learningContent and ancestor::*[fonto:dita-class(., "topic/topic")]',
+		xq`self::learningContent and ancestor::*[fonto:dita-class(., "topic/topic")]`,
 		undefined,
 		{
 			defaultTextContainer: 'learningContentbody',
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in learningContent
-	configureAsTitleFrame(sxModule, 'self::title[parent::learningContent]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::learningContent]`, undefined, {
 		fontVariation: 'document-title'
 	});
 
 	// learningContentbody
 	//     The <learningContentbody> element is the main body-level element in a learningContent topic.
-	configureAsStructure(sxModule, 'self::learningContentbody', t('body'), {
+	configureAsStructure(sxModule, xq`self::learningContentbody`, t('body'), {
 		defaultTextContainer: 'section',
 		isIgnoredForNavigation: false,
 		isRemovableIfEmpty: false
 	});
 
 	// section in learningContentbody
-	configureContextualOperations(sxModule, 'self::section[parent::learningContentbody]', [
+	configureContextualOperations(sxModule, xq`self::section[parent::learningContentbody]`, [
 		{ name: ':section-insert-title' },
 		{ name: ':contextual-delete-section' }
 	]);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-interaction-base2domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-interaction-base2domain/src/configureSxModule.js
@@ -1,17 +1,18 @@
 import configureAsRemoved from 'fontoxml-families/src/configureAsRemoved.js';
 import configureAsTitleFrame from 'fontoxml-families/src/configureAsTitleFrame.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// lcInteractionBase2
-	configureAsRemoved(sxModule, 'self::lcInteractionBase2', t('lcInteractionBase2'));
+	configureAsRemoved(sxModule, xq`self::lcInteractionBase2`, t('lcInteractionBase2'));
 
 	// lcInteractionLabel2
-	configureAsTitleFrame(sxModule, 'self::lcInteractionLabel2', t('interaction label'), {
+	configureAsTitleFrame(sxModule, xq`self::lcInteractionLabel2`, t('interaction label'), {
 		emptyElementPlaceholderText: t('type the interaction label'),
 		fontVariation: 'figure-title'
 	});
 
 	// lcQuestionBase2
-	configureAsRemoved(sxModule, 'self::lcQuestionBase2', t('lcQuestionBase2'));
+	configureAsRemoved(sxModule, xq`self::lcQuestionBase2`, t('lcQuestionBase2'));
 }

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-overview-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-overview-mod/src/configureSxModule.js
@@ -6,20 +6,21 @@ import configureContextualOperations from 'fontoxml-families/src/configureContex
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// learningOverview
 	//     A Learning Overview topic identifies the learning objectives, includes other information helpful to
 	//     the learner, such as prerequisites, duration, intended audience, and can include information and
 	//     strategies that seeks to gain attention and stimulate recall of prior learning.
-	configureAsSheetFrame(sxModule, 'self::learningOverview', t('learning overview'), {
+	configureAsSheetFrame(sxModule, xq`self::learningOverview`, t('learning overview'), {
 		defaultTextContainer: 'learningOverviewbody',
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -28,19 +29,19 @@ export default function configureSxModule(sxModule) {
 	// learningOverview nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::learningOverview and ancestor::*[fonto:dita-class(., "topic/topic")]',
+		xq`self::learningOverview and ancestor::*[fonto:dita-class(., "topic/topic")]`,
 		undefined,
 		{
 			defaultTextContainer: 'learningOverviewbody',
 			titleQuery:
-				'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+				xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in learningOverview
-	configureAsTitleFrame(sxModule, 'self::title[parent::learningOverview]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::learningOverview]`, undefined, {
 		fontVariation: 'document-title'
 	});
 
@@ -49,14 +50,14 @@ export default function configureSxModule(sxModule) {
 	//     learningOverviewbody has a very specific structure, with the following elements in this order:
 	//     <lcIntro>, <lcAudience>, <lcDuration>, <lcPrereqs>, <lcObjectives>, <lcResources>, followed by one
 	//     or more <section> elements. Each of the learningOverviewbody sections are optional.
-	configureAsStructure(sxModule, 'self::learningOverviewbody', t('body'), {
+	configureAsStructure(sxModule, xq`self::learningOverviewbody`, t('body'), {
 		defaultTextContainer: 'section',
 		isIgnoredForNavigation: false,
 		isRemovableIfEmpty: false
 	});
 
 	// section in learningOverviewbody
-	configureContextualOperations(sxModule, 'self::section[parent::learningOverviewbody]', [
+	configureContextualOperations(sxModule, xq`self::section[parent::learningOverviewbody]`, [
 		{ name: ':section-insert-title' },
 		{ name: ':contextual-delete-section' }
 	]);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.js
@@ -174,6 +174,7 @@ export default function configureSxModule(sxModule) {
 	// lcGapItem
 	//     The <lcGapItem> describes gaps between existing training objectives and related job-task-analysis
 	//     content.
+	// TODO: Upgrade the createLabelQueryWidget when it accepts XQuery template tags in 7.18
 	configureAsFrame(sxModule, xq`self::lcGapItem`, t('gap item'), {
 		contextualOperations: [
 			{ name: ':lcGapItem-insert-title' },
@@ -188,7 +189,7 @@ export default function configureSxModule(sxModule) {
 		isIgnoredForNavigation: false,
 		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
-		blockOutsideBefore: [createLabelQueryWidget(xq`"\u25cf"`)],
+		blockOutsideBefore: [createLabelQueryWidget(`"\u25cf"`)],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
@@ -266,6 +267,7 @@ export default function configureSxModule(sxModule) {
 	// lcInterventionItem
 	//     The <lcInterventionItem> describes how learning content is built, based on a systems approach to
 	//     analyzing, designing, developing, implementing, and evaluating any instructional experience.
+	// TODO: Upgrade the createLabelQueryWidget when it accepts XQuery template tags in 7.18
 	configureAsFrame(sxModule, xq`self::lcInterventionItem`, t('intervention item'), {
 		contextualOperations: [
 			{ name: ':lcInterventionItem-insert-title' },
@@ -490,7 +492,7 @@ export default function configureSxModule(sxModule) {
 
 	// lcPlanResources
 	//     The <lcPlanResources> describes resource needs.
-	configureAsFrameWithBlock(sxModule, 'self::lcPlanResources', t('plan resources'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcPlanResources`, t('plan resources'), {
 		emptyElementPlaceholderText: t('type the plan resources'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -739,7 +741,7 @@ export default function configureSxModule(sxModule) {
 		blockFooter: [
 			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -748,30 +750,30 @@ export default function configureSxModule(sxModule) {
 	// learningPlan nested in topic
 	configureAsFrame(
 		sxModule,
-		`self::learningPlan and ancestor::*[fonto:dita-class(., "topic/topic")]`,
+		xq`self::learningPlan and ancestor::*[fonto:dita-class(., "topic/topic")]`,
 		undefined,
 		{
 			defaultTextContainer: 'learningPlanbody',
-			blockFooter: [createRelatedNodesQueryWidget(`./related-links`)],
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in learningPlan
-	configureAsTitleFrame(sxModule, `self::title[parent::learningPlan]`, undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::learningPlan]`, undefined, {
 		fontVariation: 'document-title'
 	});
 
 	// learningPlanbody
 	//     The <learningPlanbody> element is the main body-level element in a learningPlan topic.
-	configureAsStructure(sxModule, `self::learningPlanbody`, t('body'), {
+	configureAsStructure(sxModule, xq`self::learningPlanbody`, t('body'), {
 		defaultTextContainer: 'section',
 		isIgnoredForNavigation: false,
 		isRemovableIfEmpty: false
 	});
 
 	// section in learningPlanbody
-	configureContextualOperations(sxModule, `self::section[parent::learningPlanbody]`, [
+	configureContextualOperations(sxModule, xq`self::section[parent::learningPlanbody]`, [
 		{ name: ':section-insert-title' },
 		{ name: ':contextual-delete-section' }
 	]);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.js
@@ -9,26 +9,27 @@ import createLabelQueryWidget from 'fontoxml-families/src/createLabelQueryWidget
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// lcAge
 	//     The <lcAge> provides the age range of the intended learner audience, for use by curriculum
 	//     developers and course planners.
-	configureAsFrameWithBlock(sxModule, 'self::lcAge', t('age'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcAge`, t('age'), {
 		emptyElementPlaceholderText: t('type the age'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcAssessment
 	//     The <lcAssessment> describes assessment plans.
-	configureAsFrameWithBlock(sxModule, 'self::lcAssessment', t('assessment'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcAssessment`, t('assessment'), {
 		emptyElementPlaceholderText: t('type the assessment plans'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcAttitude
 	//     The <lcAttitude> describes mental state that influences the choices of personal actions.
-	configureAsFrameWithBlock(sxModule, 'self::lcAttitude', t('attitude'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcAttitude`, t('attitude'), {
 		emptyElementPlaceholderText: t('type the attitude'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -36,49 +37,49 @@ export default function configureSxModule(sxModule) {
 	// lcBackground
 	//     The <lcBackground> provides the learners' professional background and the relevancy to the learning
 	//     plan.
-	configureAsFrameWithBlock(sxModule, 'self::lcBackground', t('background'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcBackground`, t('background'), {
 		emptyElementPlaceholderText: t('type the background'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcCIN
 	//     The <lcCIN> provides an alternate identifier for the project title.
-	configureAsFrame(sxModule, 'self::lcCIN', t('CIN'), {
+	configureAsFrame(sxModule, xq`self::lcCIN`, t('CIN'), {
 		contextualOperations: [
 			{ name: ':lcCIN-insert-title' },
 			{ name: ':contextual-delete-lcCIN' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the alternate identifier'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcClassroom
 	//     The <lcClassroom> describes the classroom environment.
-	configureAsFrame(sxModule, 'self::lcClassroom', t('classroom'), {
+	configureAsFrame(sxModule, xq`self::lcClassroom`, t('classroom'), {
 		contextualOperations: [
 			{ name: ':lcClassroom-insert-title' },
 			{ name: ':contextual-delete-lcClassroom' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the classroom environment'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcClient
 	//     The <lcClient> provides the person or organization sponsoring or requiring the learning event development.
-	configureAsFrame(sxModule, 'self::lcClient', t('client'), {
+	configureAsFrame(sxModule, xq`self::lcClient`, t('client'), {
 		contextualOperations: [
 			{ name: ':lcClient-insert-title' },
 			{ name: ':contextual-delete-lcClient' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the clients name'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -86,35 +87,35 @@ export default function configureSxModule(sxModule) {
 	// lcConstraints
 	//     The <lcConstraints> describes the organizational or technical aspects that may limit the
 	//     organization's ability to effectively use the instruction to meet its goals.
-	configureAsFrame(sxModule, 'self::lcConstraints', t('constraints'), {
+	configureAsFrame(sxModule, xq`self::lcConstraints`, t('constraints'), {
 		contextualOperations: [
 			{ name: ':lcConstraints-insert-title' },
 			{ name: ':contextual-delete-lcConstraints' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the constraints'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcDelivDate
 	//     The <lcDelivDate> provides the project delivery date.
-	configureAsFrame(sxModule, 'self::lcDelivDate', t('delivery date'), {
+	configureAsFrame(sxModule, xq`self::lcDelivDate`, t('delivery date'), {
 		contextualOperations: [
 			{ name: ':lcDelivDate-insert-title' },
 			{ name: ':contextual-delete-lcDelivDate' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the delivery date'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcDelivery
 	//     The <lcDelivery> describes the delivery method for this learning content.
-	configureAsFrameWithBlock(sxModule, 'self::lcDelivery', t('delivery'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcDelivery`, t('delivery'), {
 		emptyElementPlaceholderText: t('type the delivery method'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -122,14 +123,14 @@ export default function configureSxModule(sxModule) {
 	// lcDownloadTime
 	//     The <lcDownloadTime> describes the maximum time allowed for download time in the client's delivery
 	//     environment.
-	configureAsFrame(sxModule, 'self::lcDownloadTime', t('download time'), {
+	configureAsFrame(sxModule, xq`self::lcDownloadTime`, t('download time'), {
 		contextualOperations: [
 			{ name: ':lcDownloadTime-insert-title' },
 			{ name: ':contextual-delete-lcDownloadTime' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the download time'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -137,35 +138,35 @@ export default function configureSxModule(sxModule) {
 	// lcEdLevel
 	//     The <lcEdLevel> provides the range of learners' education level and the relevancy to the learning
 	//     plan.
-	configureAsFrameWithBlock(sxModule, 'self::lcEdLevel', t('education level'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcEdLevel`, t('education level'), {
 		emptyElementPlaceholderText: t('type the education level'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcFileSizeLimitations
 	//     The <lcFileSizeLimitations> describes any file size limitation in the download environment.
-	configureAsFrame(sxModule, 'self::lcFileSizeLimitations', t('file size limitations'), {
+	configureAsFrame(sxModule, xq`self::lcFileSizeLimitations`, t('file size limitations'), {
 		contextualOperations: [
 			{ name: ':lcFileSizeLimitations-insert-title' },
 			{ name: ':contextual-delete-lcFileSizeLimitations' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the file size limitations'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcGapAnalysis
 	//     The <lcGapAnalysis> compares existing learning objectives to current job task analysis.
-	configureAsFrame(sxModule, 'self::lcGapAnalysis', t('gap analysis'), {
+	configureAsFrame(sxModule, xq`self::lcGapAnalysis`, t('gap analysis'), {
 		contextualOperations: [
 			{ name: ':lcGapAnalysis-insert-title' },
 			{ name: ':contextual-delete-lcGapAnalysis' }
 		],
 		defaultTextContainer: 'lcGapItem',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -173,7 +174,7 @@ export default function configureSxModule(sxModule) {
 	// lcGapItem
 	//     The <lcGapItem> describes gaps between existing training objectives and related job-task-analysis
 	//     content.
-	configureAsFrame(sxModule, 'self::lcGapItem', t('gap item'), {
+	configureAsFrame(sxModule, xq`self::lcGapItem`, t('gap item'), {
 		contextualOperations: [
 			{ name: ':lcGapItem-insert-title' },
 			{ name: ':contextual-insert-lcPlanObjective' },
@@ -185,15 +186,15 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
-		blockOutsideBefore: [createLabelQueryWidget('"\u25cf"')],
+		blockOutsideBefore: [createLabelQueryWidget(xq`"\u25cf"`)],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcGapItemDelta
 	//     The <lcGapItemDelta> describes the gap between the learning objective and the task analysis.
-	configureAsFrameWithBlock(sxModule, 'self::lcGapItemDelta', t('gap item delta'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcGapItemDelta`, t('gap item delta'), {
 		emptyElementPlaceholderText: t(
 			'describe the gap between the learning objective and the task analysis'
 		),
@@ -203,7 +204,7 @@ export default function configureSxModule(sxModule) {
 	// lcGeneralDescription
 	//     The <lcGeneralDescription> provides a space to develop a general description about the
 	//     organization's training needs.
-	configureAsFrameWithBlock(sxModule, 'self::lcGeneralDescription', t('general description'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcGeneralDescription`, t('general description'), {
 		emptyElementPlaceholderText: t('type the general description'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -212,7 +213,7 @@ export default function configureSxModule(sxModule) {
 	//     The <lcGoals> provides the outcomes desired by the organization to be addressed by the training
 	//     effort. These goals may require concurrent efforts outside of training such as technology
 	//     acquisition, reorganization, and so forth.
-	configureAsFrameWithBlock(sxModule, 'self::lcGoals', t('goals'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcGoals`, t('goals'), {
 		emptyElementPlaceholderText: t('type the goals'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -220,14 +221,14 @@ export default function configureSxModule(sxModule) {
 	// lcGraphics
 	//     The <lcGraphics> describes standards and system requirements for displaying graphics and other
 	//     related content types.
-	configureAsFrame(sxModule, 'self::lcGraphics', t('graphics'), {
+	configureAsFrame(sxModule, xq`self::lcGraphics`, t('graphics'), {
 		contextualOperations: [
 			{ name: ':lcGraphics-insert-title' },
 			{ name: ':contextual-delete-lcGraphics' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the graphic requirements'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -235,14 +236,14 @@ export default function configureSxModule(sxModule) {
 	// lcHandouts
 	//     The <lcHandouts> provides aspects of the course that are provided by the instructor in support of
 	//     the course learning objectives.
-	configureAsFrame(sxModule, 'self::lcHandouts', t('handouts'), {
+	configureAsFrame(sxModule, xq`self::lcHandouts`, t('handouts'), {
 		contextualOperations: [
 			{ name: ':lcHandouts-insert-title' },
 			{ name: ':contextual-delete-lcHandouts' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the handouts'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -250,14 +251,14 @@ export default function configureSxModule(sxModule) {
 	// lcIntervention
 	//     The <lcIntervention> describes the approach and strategies to building the learning materials, based
 	//     on the needs analysis.
-	configureAsFrame(sxModule, 'self::lcIntervention', t('intervention'), {
+	configureAsFrame(sxModule, xq`self::lcIntervention`, t('intervention'), {
 		contextualOperations: [
 			{ name: ':lcIntervention-insert-title' },
 			{ name: ':contextual-delete-lcIntervention' }
 		],
 		defaultTextContainer: 'lcInterventionItem',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -265,7 +266,7 @@ export default function configureSxModule(sxModule) {
 	// lcInterventionItem
 	//     The <lcInterventionItem> describes how learning content is built, based on a systems approach to
 	//     analyzing, designing, developing, implementing, and evaluating any instructional experience.
-	configureAsFrame(sxModule, 'self::lcInterventionItem', t('intervention item'), {
+	configureAsFrame(sxModule, xq`self::lcInterventionItem`, t('intervention item'), {
 		contextualOperations: [
 			{ name: ':lcInterventionItem-insert-title' },
 			{ name: ':lcInterventionItem-insert-lcLearnStrat' },
@@ -278,7 +279,7 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideBefore: [createLabelQueryWidget('"\u25cf"')],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
@@ -287,14 +288,14 @@ export default function configureSxModule(sxModule) {
 	// lcJtaItem
 	//     The <lcJtaItem> provides description of job task analysis (JTA) as related to a particular learning
 	//     objective.
-	configureAsFrameWithBlock(sxModule, 'self::lcJtaItem', t('JTA'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcJtaItem`, t('JTA'), {
 		emptyElementPlaceholderText: t('type the job task analysis'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcKnowledge
 	//     <lcKnowledge> provides the learners' current knowledge of the learning topics.
-	configureAsFrameWithBlock(sxModule, 'self::lcKnowledge', t('knowledge'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcKnowledge`, t('knowledge'), {
 		emptyElementPlaceholderText: t('type the knowledge'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -302,49 +303,49 @@ export default function configureSxModule(sxModule) {
 	// lcLearnStrat
 	//     The <lcLearnStrat> describes the manner in which the learning content will be instructed. This
 	//     should be a high level design that applies instructional-design theories and models.
-	configureAsFrameWithBlock(sxModule, 'self::lcLearnStrat', t('learning strategy'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcLearnStrat`, t('learning strategy'), {
 		emptyElementPlaceholderText: t('type the learning strategy'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcLMS
 	//     The <lcLMS> provides the LMS name and version number used in the learning event.
-	configureAsFrame(sxModule, 'self::lcLMS', t('LMS'), {
+	configureAsFrame(sxModule, xq`self::lcLMS`, t('LMS'), {
 		contextualOperations: [
 			{ name: ':lcLMS-insert-title' },
 			{ name: ':contextual-delete-lcLMS' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the LMS name'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcModDate
 	//     The <lcModDate> provides the project modification date.
-	configureAsFrame(sxModule, 'self::lcModDate', t('modification date'), {
+	configureAsFrame(sxModule, xq`self::lcModDate`, t('modification date'), {
 		contextualOperations: [
 			{ name: ':lcModDate-insert-title' },
 			{ name: ':contextual-delete-lcModDate' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the modification date'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcMotivation
 	//     The <lcMotivation> provides the reasons why the learners want and/or need to take the instruction.
-	configureAsFrameWithBlock(sxModule, 'self::lcMotivation', t('motivation'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcMotivation`, t('motivation'), {
 		emptyElementPlaceholderText: t('type the motivation'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcNeeds
 	//     The <lcNeeds> provides the needs behind the outcomes described by the <lcGoals>.
-	configureAsFrameWithBlock(sxModule, 'self::lcNeeds', t('needs'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcNeeds`, t('needs'), {
 		emptyElementPlaceholderText: t('type the needs'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -353,7 +354,7 @@ export default function configureSxModule(sxModule) {
 	//     The <lcNeedsAnalysis> describes the training requirement and identifies the need to develop or
 	//     revise content. These include periodic training gap analyses, changes to operational or maintenance
 	//     requirements, and changes to equipment or systems.
-	configureAsFrame(sxModule, 'self::lcNeedsAnalysis', t('needs analysis'), {
+	configureAsFrame(sxModule, xq`self::lcNeedsAnalysis`, t('needs analysis'), {
 		contextualOperations: [
 			{ name: ':lcNeedsAnalysis-insert-title' },
 			{ name: ':lcNeedsAnalysis-insert-lcOrganizational' },
@@ -368,7 +369,7 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -376,13 +377,13 @@ export default function configureSxModule(sxModule) {
 	// lcNoLMS
 	//     Use <lcNoLMS> when you plan to deliver the content as a standalone package, without a learning
 	//     management system (LMS).
-	configureAsFrame(sxModule, 'self::lcNoLMS', t('no LMS'), {
+	configureAsFrame(sxModule, xq`self::lcNoLMS`, t('no LMS'), {
 		contextualOperations: [
 			{ name: ':lcNoLMS-insert-title' },
 			{ name: ':contextual-delete-lcNoLMS' }
 		],
 		defaultTextContainer: 'p',
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -390,21 +391,21 @@ export default function configureSxModule(sxModule) {
 	// lcOJT
 	//     The <lcOJT> is &#34;the job training&#34; and describes aspects of the course taking place in the
 	//     work environment.
-	configureAsFrame(sxModule, 'self::lcOJT', t('on-the-job-training'), {
+	configureAsFrame(sxModule, xq`self::lcOJT`, t('on-the-job-training'), {
 		contextualOperations: [
 			{ name: ':lcOJT-insert-title' },
 			{ name: ':contextual-delete-lcOJT' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the on-the-job-training aspects'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcOrganizational
 	//     The <lcOrganizational> describes an organization's learning requirements.
-	configureAsFrame(sxModule, 'self::lcOrganizational', t('organizational'), {
+	configureAsFrame(sxModule, xq`self::lcOrganizational`, t('organizational'), {
 		contextualOperations: [
 			{ name: ':lcOrganizational-insert-title' },
 			{ name: ':contextual-insert-lcGeneralDescription' },
@@ -416,7 +417,7 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -424,14 +425,14 @@ export default function configureSxModule(sxModule) {
 	// lcOrgConstraints
 	//     The <lcOrgConstraints> provides organizational aspects that may limit the organization's ability to
 	//     effectively use the instruction to meet its goals.
-	configureAsFrameWithBlock(sxModule, 'self::lcOrgConstraints', t('organizational constraints'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcOrgConstraints`, t('organizational constraints'), {
 		emptyElementPlaceholderText: t('type the organizational constraints'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcPlanAudience
 	//     The <lcPlanAudience> describes characteristics of the learners who take the instruction.
-	configureAsFrame(sxModule, 'self::lcPlanAudience', t('plan audience'), {
+	configureAsFrame(sxModule, xq`self::lcPlanAudience`, t('plan audience'), {
 		contextualOperations: [
 			{ name: ':lcPlanAudience-insert-title' },
 			{ name: ':contextual-insert-lcGeneralDescription' },
@@ -446,28 +447,28 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcPlanDescrip
 	//     The <lcPlanDescrip> provides a plan description.
-	configureAsFrame(sxModule, 'self::lcPlanDescrip', t('plan description'), {
+	configureAsFrame(sxModule, xq`self::lcPlanDescrip`, t('plan description'), {
 		contextualOperations: [
 			{ name: ':lcPlanDescrip-insert-title' },
 			{ name: ':contextual-delete-lcPlanDescrip' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the plan description'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcPlanObjective
 	//     The <lcPlanObjective> describes the objective to be addressed by a gap analysis or intervention.
-	configureAsFrameWithBlock(sxModule, 'self::lcPlanObjective', t('plan objective'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcPlanObjective`, t('plan objective'), {
 		emptyElementPlaceholderText: t('type the plan objective'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -475,14 +476,14 @@ export default function configureSxModule(sxModule) {
 	// lcPlanPrereqs
 	//     <lcPlanPrereqs> provides the knowledge, skills, abilities, courses and other activities learners
 	//     must have satisfied to take the instruction.
-	configureAsFrame(sxModule, 'self::lcPlanPrereqs', t('plan prerequisites'), {
+	configureAsFrame(sxModule, xq`self::lcPlanPrereqs`, t('plan prerequisites'), {
 		contextualOperations: [
 			{ name: ':lcPlanPrereqs-insert-title' },
 			{ name: ':contextual-delete-lcPlanPrereqs' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the plan prerequisites'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -496,56 +497,56 @@ export default function configureSxModule(sxModule) {
 
 	// lcPlanSubject
 	//     The <lcPlanSubject> provides a complete description of the subject of the planned learning.
-	configureAsFrame(sxModule, 'self::lcPlanSubject', t('plan subject'), {
+	configureAsFrame(sxModule, xq`self::lcPlanSubject`, t('plan subject'), {
 		contextualOperations: [
 			{ name: ':lcPlanSubject-insert-title' },
 			{ name: ':contextual-delete-lcPlanSubject' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the plan subject'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcPlanTitle
 	//     The <lcPlanTitle> provides a title for this plan.
-	configureAsFrame(sxModule, 'self::lcPlanTitle', t('plan title'), {
+	configureAsFrame(sxModule, xq`self::lcPlanTitle`, t('plan title'), {
 		contextualOperations: [
 			{ name: ':lcPlanTitle-insert-title' },
 			{ name: ':contextual-delete-lcPlanTitle' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the plan title'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcPlayers
 	//     The <lcPlayers> describes tools and plugins used for time-sequenced display at runtime.
-	configureAsFrame(sxModule, 'self::lcPlayers', t('players'), {
+	configureAsFrame(sxModule, xq`self::lcPlayers`, t('players'), {
 		contextualOperations: [
 			{ name: ':lcPlayers-insert-title' },
 			{ name: ':contextual-delete-lcPlayers' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the players'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcProcesses
 	//     The <lcProcesses> describes processes learners routinely follow.
-	configureAsFrameWithBlock(sxModule, 'self::lcProcesses', t('processes'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcProcesses`, t('processes'), {
 		emptyElementPlaceholderText: t('type the processes'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcProject
 	//     The <lcProject> provides learning content project plan description information.
-	configureAsFrame(sxModule, 'self::lcProject', t('project'), {
+	configureAsFrame(sxModule, xq`self::lcProject`, t('project'), {
 		contextualOperations: [
 			{ name: ':lcProject-insert-title' },
 			{ name: ':lcProject-insert-lcClient' },
@@ -560,42 +561,42 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcResolution
 	//     The <lcResolution> describes the required computer screen resolution for the online instruction.
-	configureAsFrame(sxModule, 'self::lcResolution', t('resolution'), {
+	configureAsFrame(sxModule, xq`self::lcResolution`, t('resolution'), {
 		contextualOperations: [
 			{ name: ':lcResolution-insert-title' },
 			{ name: ':contextual-delete-lcResolution' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the resolution'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcSecurity
 	//     The <lcSecurity> describes the security requirements in the delivered instruction.
-	configureAsFrame(sxModule, 'self::lcSecurity', t('security'), {
+	configureAsFrame(sxModule, xq`self::lcSecurity`, t('security'), {
 		contextualOperations: [
 			{ name: ':lcSecurity-insert-title' },
 			{ name: ':contextual-delete-lcSecurity' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the security'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcSkills
 	//     The <lcSkills> describes the learners' current skill set and the relevancy to the learning plan.
-	configureAsFrameWithBlock(sxModule, 'self::lcSkills', t('skills'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcSkills`, t('skills'), {
 		emptyElementPlaceholderText: t('type the skills'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -603,14 +604,14 @@ export default function configureSxModule(sxModule) {
 	// lcSpecChars
 	//     The <lcSpecChars> provides learner characteristics specific to the population that will influence
 	//     the design, including learning disabilities, physical handicaps, and so forth.
-	configureAsFrameWithBlock(sxModule, 'self::lcSpecChars', t('specific characteristics'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcSpecChars`, t('specific characteristics'), {
 		emptyElementPlaceholderText: t('type the specific characteristics'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcTask
 	//     The <lcTask> captures a work item to be performed, as part of the learning plan.
-	configureAsFrame(sxModule, 'self::lcTask', t('task'), {
+	configureAsFrame(sxModule, xq`self::lcTask`, t('task'), {
 		contextualOperations: [
 			{ name: ':lcTask-insert-title' },
 			{ name: ':lcTask-append-lcTaskItem', hideIn: ['context-menu'] },
@@ -622,14 +623,14 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcTaskItem
 	//     The <lcTaskItem> describes a discreet task to be taught.
-	configureAsFrameWithBlock(sxModule, 'self::lcTaskItem', t('task item'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcTaskItem`, t('task item'), {
 		emptyElementPlaceholderText: t('type the task item'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -637,7 +638,7 @@ export default function configureSxModule(sxModule) {
 	// lcTechnical
 	//     The <lcTechnical> describes the technical requirements to the learning content and how those
 	//     requirements are supported by the instructional design.
-	configureAsFrame(sxModule, 'self::lcTechnical', t('technical'), {
+	configureAsFrame(sxModule, xq`self::lcTechnical`, t('technical'), {
 		contextualOperations: [
 			{ name: ':lcTechnical-insert-title' },
 			{ name: ':lcTechnical-insert-lcLMS' },
@@ -658,49 +659,49 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcValues
 	//     The <lcValues> describes affective components of desired instructional outcomes.
-	configureAsFrameWithBlock(sxModule, 'self::lcValues', t('values'), {
+	configureAsFrameWithBlock(sxModule, xq`self::lcValues`, t('values'), {
 		emptyElementPlaceholderText: t('type the values'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// lcViewers
 	//     The <lcViewers> describes viewers used for time-sequenced display at runtime.
-	configureAsFrame(sxModule, 'self::lcViewers', t('viewers'), {
+	configureAsFrame(sxModule, xq`self::lcViewers`, t('viewers'), {
 		contextualOperations: [
 			{ name: ':lcViewers-insert-title' },
 			{ name: ':contextual-delete-lcViewers' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the viewers'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcW3C
 	//     The <lcW3C> provides requirements for use of world wide web consortium standards.
-	configureAsFrame(sxModule, 'self::lcW3C', t('W3C'), {
+	configureAsFrame(sxModule, xq`self::lcW3C`, t('W3C'), {
 		contextualOperations: [
 			{ name: ':lcW3C-insert-title' },
 			{ name: ':contextual-delete-lcW3C' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the W3C requirements'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcWorkEnv
 	//     The <lcWorkEnv> describes the working conditions and contexts in which the training will be applied.
-	configureAsFrame(sxModule, 'self::lcWorkEnv', t('work environment'), {
+	configureAsFrame(sxModule, xq`self::lcWorkEnv`, t('work environment'), {
 		contextualOperations: [
 			{ name: ':lcWorkEnv-insert-title' },
 			{ name: ':lcWorkEnv-insert-lcWorkEnvDescription' },
@@ -710,7 +711,7 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -720,7 +721,7 @@ export default function configureSxModule(sxModule) {
 	//     applied.
 	configureAsFrameWithBlock(
 		sxModule,
-		'self::lcWorkEnvDescription',
+		xq`self::lcWorkEnvDescription`,
 		t('work environment description'),
 		{
 			emptyElementPlaceholderText: t('type the work environment description'),
@@ -731,14 +732,14 @@ export default function configureSxModule(sxModule) {
 	// learningPlan
 	//     A Learning Plan topic describes learning needs and goals, instructional design models, task
 	//     analyses, learning taxonomies, and other information necessary to the lesson planning process.
-	configureAsSheetFrame(sxModule, 'self::learningPlan', t('learning plan'), {
+	configureAsSheetFrame(sxModule, xq`self::learningPlan`, t('learning plan'), {
 		defaultTextContainer: 'learningPlanbody',
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -747,30 +748,30 @@ export default function configureSxModule(sxModule) {
 	// learningPlan nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::learningPlan and ancestor::*[fonto:dita-class(., "topic/topic")]',
+		`self::learningPlan and ancestor::*[fonto:dita-class(., "topic/topic")]`,
 		undefined,
 		{
 			defaultTextContainer: 'learningPlanbody',
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+			blockFooter: [createRelatedNodesQueryWidget(`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in learningPlan
-	configureAsTitleFrame(sxModule, 'self::title[parent::learningPlan]', undefined, {
+	configureAsTitleFrame(sxModule, `self::title[parent::learningPlan]`, undefined, {
 		fontVariation: 'document-title'
 	});
 
 	// learningPlanbody
 	//     The <learningPlanbody> element is the main body-level element in a learningPlan topic.
-	configureAsStructure(sxModule, 'self::learningPlanbody', t('body'), {
+	configureAsStructure(sxModule, `self::learningPlanbody`, t('body'), {
 		defaultTextContainer: 'section',
 		isIgnoredForNavigation: false,
 		isRemovableIfEmpty: false
 	});
 
 	// section in learningPlanbody
-	configureContextualOperations(sxModule, 'self::section[parent::learningPlanbody]', [
+	configureContextualOperations(sxModule, `self::section[parent::learningPlanbody]`, [
 		{ name: ':section-insert-title' },
 		{ name: ':contextual-delete-section' }
 	]);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-summary-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-summary-mod/src/configureSxModule.js
@@ -6,20 +6,21 @@ import configureContextualOperations from 'fontoxml-families/src/configureContex
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// learningSummary
 	//     A Learning Summary recaps and provides context for the achievement or accomplishment of learning
 	//     objectives, provides guidance to reinforce learning and long-term memory, and may pose questions to
 	//     enhance encoding and verification of the learning content.
-	configureAsSheetFrame(sxModule, 'self::learningSummary', t('learning summary'), {
+	configureAsSheetFrame(sxModule, xq`self::learningSummary`, t('learning summary'), {
 		defaultTextContainer: 'learningSummarybody',
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -28,30 +29,30 @@ export default function configureSxModule(sxModule) {
 	// learningSummary nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::learningSummary and ancestor::*[fonto:dita-class(., "topic/topic")]',
+		xq`self::learningSummary and ancestor::*[fonto:dita-class(., "topic/topic")]`,
 		undefined,
 		{
 			defaultTextContainer: 'learningSummarybody',
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in learningSummary
-	configureAsTitleFrame(sxModule, 'self::title[parent::learningSummary]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::learningSummary]`, undefined, {
 		fontVariation: 'document-title'
 	});
 
 	// learningSummarybody
 	//     The <learningSummarybody> element is the main body-level element in a learningSummary topic.
-	configureAsStructure(sxModule, 'self::learningSummarybody', t('body'), {
+	configureAsStructure(sxModule, xq`self::learningSummarybody`, t('body'), {
 		defaultTextContainer: 'section',
 		isIgnoredForNavigation: false,
 		isRemovableIfEmpty: false
 	});
 
 	// section in learningSummarybody
-	configureContextualOperations(sxModule, 'self::section[parent::learningSummarybody]', [
+	configureContextualOperations(sxModule, xq`self::section[parent::learningSummarybody]`, [
 		{ name: ':section-insert-title' },
 		{ name: ':contextual-delete-section' }
 	]);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.js
@@ -33,7 +33,7 @@ export default function insertNodeAndRemoveFromSiblings(argument, blueprint) {
 		.concat(evaluateXPathToNodes(xq`following-sibling::*`, contextNode, blueprint))
 		.forEach(function(siblingNode) {
 			var removeNode = evaluateXPathToFirstNode(
-				xq(`child::${argument.nodeName}`),
+				xq(`child::*[name() = ${argument.nodeName}]`),
 				siblingNode,
 				blueprint
 			);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.js
@@ -2,13 +2,14 @@ import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult.js
 import blueprintQuery from 'fontoxml-blueprints/src/blueprintQuery.js';
 import evaluateXPathToFirstNode from 'fontoxml-selectors/src/evaluateXPathToFirstNode.js';
 import evaluateXPathToNodes from 'fontoxml-selectors/src/evaluateXPathToNodes.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 /**
  * Arguments:
- * @param {NodeId} contextNodeId      The node in which the new node should be inserted.
- * @param {string} nodeName           The name of the node that needs to be inserted and removed.
- * @param {string} referenceNodeQuery A Xpath Query to find a node which should become the next
- *                                      sibling of the new node.
+ * @param {NodeId} contextNodeId      	               The node in which the new node should be inserted.
+ * @param {string} nodeName                            The name of the node that needs to be inserted and removed.
+ * @param {string | XQExpression} referenceNodeQuery   An XPath Query or XQExpression to find a node 
+ * 										               which should become the next sibling of the new node.
  */
 export default function insertNodeAndRemoveFromSiblings(argument, blueprint) {
 	var contextNode = blueprint.lookup(argument.contextNodeId);
@@ -28,11 +29,11 @@ export default function insertNodeAndRemoveFromSiblings(argument, blueprint) {
 
 	blueprint.insertBefore(contextNode, newNode, referenceNode);
 
-	evaluateXPathToNodes('preceding-sibling::*', contextNode, blueprint)
-		.concat(evaluateXPathToNodes('following-sibling::*', contextNode, blueprint))
+	evaluateXPathToNodes(xq`preceding-sibling::*`, contextNode, blueprint)
+		.concat(evaluateXPathToNodes(xq`following-sibling::*`, contextNode, blueprint))
 		.forEach(function(siblingNode) {
 			var removeNode = evaluateXPathToFirstNode(
-				'child::' + argument.nodeName,
+				xq`child::${argument.nodeName}`,
 				siblingNode,
 				blueprint
 			);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.js
@@ -33,7 +33,7 @@ export default function insertNodeAndRemoveFromSiblings(argument, blueprint) {
 		.concat(evaluateXPathToNodes(xq`following-sibling::*`, contextNode, blueprint))
 		.forEach(function(siblingNode) {
 			var removeNode = evaluateXPathToFirstNode(
-				xq`child::${argument.nodeName}`,
+				xq(`child::${argument.nodeName}`),
 				siblingNode,
 				blueprint
 			);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.js
@@ -33,7 +33,7 @@ export default function insertNodeAndRemoveFromSiblings(argument, blueprint) {
 		.concat(evaluateXPathToNodes(xq`following-sibling::*`, contextNode, blueprint))
 		.forEach(function(siblingNode) {
 			var removeNode = evaluateXPathToFirstNode(
-				xq(`child::*[name() = ${argument.nodeName}]`),
+				xq`child::*[name() = ${argument.nodeName}]`,
 				siblingNode,
 				blueprint
 			);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/configureSxModule.js
@@ -8,35 +8,36 @@ import createIconWidget from 'fontoxml-families/src/createIconWidget.js';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createOrderingByAttributeWidget from 'fontoxml-families/src/createOrderingByAttributeWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// lcAnswerContent2
 	//     The <lcAnswerContent2> element in a learning assessment interaction provides the content for an
 	//     answer option, which the learner can select as correct or incorrect.
-	configureAsStructure(sxModule, 'self::lcAnswerContent2', t('answer option content'), {
+	configureAsStructure(sxModule, xq`self::lcAnswerContent2`, t('answer option content'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the incorrect answer option')
 	});
 
-	configureProperties(sxModule, 'self::lcAnswerContent2[following-sibling::lcCorrectResponse2]', {
+	configureProperties(sxModule, xq`self::lcAnswerContent2[following-sibling::lcCorrectResponse2]`, {
 		emptyElementPlaceholderText: t('type the correct answer option')
 	});
 
-	configureProperties(sxModule, 'self::lcAnswerContent2[parent::lcSequenceOption2]', {
+	configureProperties(sxModule, xq`self::lcAnswerContent2[parent::lcSequenceOption2]`, {
 		emptyElementPlaceholderText: t('type the answer option')
 	});
 
 	// lcAnswerOption2
 	//     The <lcAnswerOption2> element in an assessment interaction provides the content and feedback for a
 	//     question option, and can indicate the correct option.
-	configureAsFrame(sxModule, 'self::lcAnswerOption2', t('answer option'), {
+	configureAsFrame(sxModule, xq`self::lcAnswerOption2`, t('answer option'), {
 		defaultTextContainer: 'lcAnswerContent2',
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	configureProperties(
 		sxModule,
-		'self::lcAnswerOption2[parent::*/parent::*[self::lcSingleSelect2 or self::lcTrueFalse2]]',
+		xq`self::lcAnswerOption2[parent::*/parent::*[self::lcSingleSelect2 or self::lcTrueFalse2]]`,
 		{
 			markupLabel: t('incorrect answer option'),
 			blockBefore: [
@@ -50,7 +51,7 @@ export default function configureSxModule(sxModule) {
 
 	configureProperties(
 		sxModule,
-		'self::lcAnswerOption2[parent::*/parent::*[self::lcSingleSelect2]]',
+		xq`self::lcAnswerOption2[parent::*/parent::*[self::lcSingleSelect2]]`,
 		{
 			priority: 2,
 			contextualOperations: [
@@ -65,7 +66,7 @@ export default function configureSxModule(sxModule) {
 
 	configureProperties(
 		sxModule,
-		'self::lcAnswerOption2[parent::*/parent::*[self::lcSingleSelect2 or self::lcTrueFalse2] and child::lcCorrectResponse2]',
+		xq`self::lcAnswerOption2[parent::*/parent::*[self::lcSingleSelect2 or self::lcTrueFalse2] and child::lcCorrectResponse2]`,
 		{
 			markupLabel: t('correct answer option'),
 			blockBefore: [
@@ -77,7 +78,7 @@ export default function configureSxModule(sxModule) {
 		}
 	);
 
-	configureProperties(sxModule, 'self::lcAnswerOption2[parent::*/parent::lcMultipleSelect2]', {
+	configureProperties(sxModule, xq`self::lcAnswerOption2[parent::*/parent::lcMultipleSelect2]`, {
 		contextualOperations: [
 			{ name: ':contextual-move-up-answer-option' },
 			{ name: ':contextual-move-down-answer-option' },
@@ -96,7 +97,7 @@ export default function configureSxModule(sxModule) {
 
 	configureProperties(
 		sxModule,
-		'self::lcAnswerOption2[parent::*/parent::lcMultipleSelect2 and child::lcCorrectResponse2]',
+		xq`self::lcAnswerOption2[parent::*/parent::lcMultipleSelect2 and child::lcCorrectResponse2]`,
 		{
 			markupLabel: t('correct answer option'),
 			blockBefore: [
@@ -109,7 +110,7 @@ export default function configureSxModule(sxModule) {
 	);
 
 	// lcAnswerOptionGroup2
-	configureAsStructure(sxModule, 'self::lcAnswerOptionGroup2', t('answer option group'), {
+	configureAsStructure(sxModule, xq`self::lcAnswerOptionGroup2`, t('answer option group'), {
 		defaultTextContainer: 'lcAnswerOption2',
 		isIgnoredForNavigation: false
 	});
@@ -120,7 +121,7 @@ export default function configureSxModule(sxModule) {
 	//
 	// This configuration is intentionally neutral, lcArea will be further configured (for occurrences in different
 	// interaction types) in the dita-example-sx-adapter-fontoshop package.
-	configureAsFrame(sxModule, 'self::lcArea2', t('area'), {
+	configureAsFrame(sxModule, xq`self::lcArea2`, t('area'), {
 		defaultTextContainer: 'lcFeedback2',
 		contextualOperations: [
 			{ name: ':lcArea2-edit' },
@@ -135,43 +136,43 @@ export default function configureSxModule(sxModule) {
 	});
 
 	// lcAreaCoords2
-	configureAsRemoved(sxModule, 'self::lcAreaCoords2');
+	configureAsRemoved(sxModule, xq`self::lcAreaCoords2`);
 
 	// lcAreaShape2
-	configureAsRemoved(sxModule, 'self::lcAreaShape2');
+	configureAsRemoved(sxModule, xq`self::lcAreaShape2`);
 
 	// lcAsset2
 	//     The <lcAsset2> element in an assessment interaction provides the images or other graphic assets to
 	//     support the interaction.
-	configureAsStructure(sxModule, 'self::lcAsset2', t('asset'), {
+	configureAsStructure(sxModule, xq`self::lcAsset2`, t('asset'), {
 		isAutoremovableIfEmpty: true
 	});
 
 	// lcCorrectResponse2
 	//     The <lcCorrectResponse2> element in an assessment interaction indicates a correct response.
-	configureAsRemoved(sxModule, 'self::lcCorrectResponse2');
+	configureAsRemoved(sxModule, xq`self::lcCorrectResponse2`);
 
 	// lcFeedback2
 	//     The <lcFeedback2> element in an assessment interaction provides information to the learner about a
 	//     correct or incorrect response.
-	configureAsFrame(sxModule, 'self::lcFeedback2', t('answer option feedback'), {
+	configureAsFrame(sxModule, xq`self::lcFeedback2`, t('answer option feedback'), {
 		defaultTextContainer: 'p',
 		blockBefore: [createIconWidget('thumbs-down')]
 	});
 
 	configureProperties(
 		sxModule,
-		'self::lcFeedback2 or self::p[parent::lcFeedback2 and not(preceding-sibling::*)]',
+		xq`self::lcFeedback2 or self::p[parent::lcFeedback2 and not(preceding-sibling::*)]`,
 		{
 			emptyElementPlaceholderText: t('type the feedback')
 		}
 	);
 
-	configureProperties(sxModule, 'self::lcFeedback2[preceding-sibling::lcCorrectResponse2]', {
+	configureProperties(sxModule, xq`self::lcFeedback2[preceding-sibling::lcCorrectResponse2]`, {
 		blockBefore: [createIconWidget('thumbs-up')]
 	});
 
-	configureProperties(sxModule, 'self::lcFeedback2[parent::lcMatchingItemFeedback2]', {
+	configureProperties(sxModule, xq`self::lcFeedback2[parent::lcMatchingItemFeedback2]`, {
 		markupLabel: t('neutral feedback'),
 		emptyElementPlaceholderText: t('type the feedback'),
 		blockBefore: [],
@@ -181,7 +182,7 @@ export default function configureSxModule(sxModule) {
 	// lcFeedbackCorrect2
 	//     The <lcFeedbackCorrect2> element in an assessment interaction provides feedback to the learner about
 	//     a correct response.
-	configureAsFrame(sxModule, 'self::lcFeedbackCorrect2', t('feedback correct'), {
+	configureAsFrame(sxModule, xq`self::lcFeedbackCorrect2`, t('feedback correct'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the feedback for a correct response'),
 		blockHeaderLeft: [createMarkupLabelWidget()],
@@ -192,7 +193,7 @@ export default function configureSxModule(sxModule) {
 	// lcFeedbackIncorrect2
 	//     The <lcFeedbackIncorrect2> element in an assessment interaction provides feedback about incorrect
 	//     response.
-	configureAsFrame(sxModule, 'self::lcFeedbackIncorrect2', t('feedback incorrect'), {
+	configureAsFrame(sxModule, xq`self::lcFeedbackIncorrect2`, t('feedback incorrect'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the feedback for a incorrect response'),
 		blockHeaderLeft: [createMarkupLabelWidget()],
@@ -202,13 +203,13 @@ export default function configureSxModule(sxModule) {
 
 	// lcHotspot2
 	//     In a lcHotspot2 interaction, the learner clicks on a region of the screen to indicate a choice.
-	configureAsFrame(sxModule, 'self::lcHotspot2', t('hot spot'), {
+	configureAsFrame(sxModule, xq`self::lcHotspot2`, t('hot spot'), {
 		contextualOperations: [
 			{ name: ':contextual-move-up' },
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' }
 		],
-		titleQuery: './lcInteractionLabel2',
+		titleQuery: xq`./lcInteractionLabel2`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -216,13 +217,13 @@ export default function configureSxModule(sxModule) {
 	// lcHotspotMap2
 	//     A lcHotspotMap2 interaction lets you designate an action area or region over an image, allowing a
 	//     click in that region to get scored as correct or incorrect in respoinse to an interaction question.
-	configureAsStructure(sxModule, 'self::lcHotspotMap2', t('mapping'));
+	configureAsStructure(sxModule, xq`self::lcHotspotMap2`, t('mapping'));
 
 	// lcInstructornote2
 	//     Use the <lcInstructornote2> element to provide information or notes you want to provide to the
 	//     course instructor. These notes can be conditionnalized out of content you intend to deliver to the
 	//     learner.
-	configureAsFrame(sxModule, 'self::lcInstructornote2', t('instructor note'), {
+	configureAsFrame(sxModule, xq`self::lcInstructornote2`, t('instructor note'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type a note for the course instructor'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -231,7 +232,7 @@ export default function configureSxModule(sxModule) {
 	// lcItem2
 	//     The <lcItem2> element in an assessment interaction provides the content for an item that matches the
 	//     match item in a match table.
-	configureAsStructure(sxModule, 'self::lcItem2', t('item'), {
+	configureAsStructure(sxModule, xq`self::lcItem2`, t('item'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the item')
 	});
@@ -239,13 +240,13 @@ export default function configureSxModule(sxModule) {
 	// lcMatching2
 	//     In an lcMatching2 interaction, the learner identifies the correct choice that matches another
 	//     choice.
-	configureAsFrame(sxModule, 'self::lcMatching2', t('matching question'), {
+	configureAsFrame(sxModule, xq`self::lcMatching2`, t('matching question'), {
 		contextualOperations: [
 			{ name: ':contextual-move-up' },
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' }
 		],
-		titleQuery: './lcInteractionLabel2',
+		titleQuery: xq`./lcInteractionLabel2`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -253,15 +254,15 @@ export default function configureSxModule(sxModule) {
 	// lcMatchingHeader2
 	//     The <lcMatchingHeader2> element in an assessment interaction provides column headings for items to
 	//     present in a matching table.
-	configureAsDefinitionsTableRow(sxModule, 'self::lcMatchingHeader2', t('header'), {
+	configureAsDefinitionsTableRow(sxModule, xq`self::lcMatchingHeader2`, t('header'), {
 		columns: [
-			{ query: './lcItem2', width: 1 },
-			{ query: './lcMatchingItem2', width: 1 },
+			{ query: xq`./lcItem2`, width: 1 },
+			{ query: xq`./lcMatchingItem2`, width: 1 },
 			{
-				query: './lcMatchingItemFeedback2',
+				query: xq`./lcMatchingItemFeedback2`,
 				width: 2,
 				hideColumnIfQueryIsTrue:
-					'parent::lcMatchTable2[not(child::lcMatchingPair2/lcMatchingItemFeedback2)]'
+					xq`parent::lcMatchTable2[not(child::lcMatchingPair2/lcMatchingItemFeedback2)]`
 			}
 		],
 		contextualOperations: [{ name: ':contextual-delete-lcMatchingHeader2' }],
@@ -273,29 +274,29 @@ export default function configureSxModule(sxModule) {
 	// lcMatchingItem2
 	//     The <lcMatchingItem2> element in an assessment interaction provides the content for the matching
 	//     side of a matching pair of items in a match table interaction.
-	configureAsStructure(sxModule, 'self::lcMatchingItem2', t('matching item'), {
+	configureAsStructure(sxModule, xq`self::lcMatchingItem2`, t('matching item'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the matching item')
 	});
 
 	// lcMatchingItemFeedback2
 	//     ???
-	configureAsStructure(sxModule, 'self::lcMatchingItemFeedback2', t('feedback container'), {
+	configureAsStructure(sxModule, xq`self::lcMatchingItemFeedback2`, t('feedback container'), {
 		isAutoremovableIfEmpty: true
 	});
 
 	// lcMatchingPair2
 	//     The <lcMatchingPair2> element in an assessment interaction provides a table row with the pair of
 	//     items that comprise a correct match in a matching interaction.
-	configureAsDefinitionsTableRow(sxModule, 'self::lcMatchingPair2', t('matching pair'), {
+	configureAsDefinitionsTableRow(sxModule, xq`self::lcMatchingPair2`, t('matching pair'), {
 		columns: [
-			{ query: './lcItem2', width: 1 },
-			{ query: './lcMatchingItem2', width: 1 },
+			{ query: xq`./lcItem2`, width: 1 },
+			{ query: xq`./lcMatchingItem2`, width: 1 },
 			{
-				query: './lcMatchingItemFeedback2',
+				query: xq`./lcMatchingItemFeedback2`,
 				width: 2,
 				hideColumnIfQueryIsTrue:
-					'parent::lcMatchTable2[not(child::lcMatchingPair2/lcMatchingItemFeedback2)]'
+					xq`parent::lcMatchTable2[not(child::lcMatchingPair2/lcMatchingItemFeedback2)]`
 			}
 		],
 		contextualOperations: [
@@ -308,28 +309,28 @@ export default function configureSxModule(sxModule) {
 
 	// lcMatchTable2
 	//     The <lcMatchTable2> element in an assessment interaction provides a format for matching items.
-	configureAsStructure(sxModule, 'self::lcMatchTable2', t('match table'), {
+	configureAsStructure(sxModule, xq`self::lcMatchTable2`, t('match table'), {
 		tabNavigationItemSelector:
-			'name() = ("lcItem2", "lcMatchingItem2", "lcMatchingItemFeedback2")'
+			xq`name() = ("lcItem2", "lcMatchingItem2", "lcMatchingItemFeedback2")`
 	});
 
 	// lcMultipleSelect2
 	//     In an lcMultipleSelect2 interaction, the learner must indicate two or more correct answers from a
 	//     list of choices.
-	configureAsFrame(sxModule, 'self::lcMultipleSelect2', t('multiple choice'), {
+	configureAsFrame(sxModule, xq`self::lcMultipleSelect2`, t('multiple choice'), {
 		contextualOperations: [
 			{ name: ':contextual-move-up' },
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' }
 		],
-		titleQuery: './lcInteractionLabel2',
+		titleQuery: xq`./lcInteractionLabel2`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcOpenAnswer2
 	//     Use <lcOpenAnswer2> to provide a suggested answer for an <lcOpenQuestion2> interaction.
-	configureAsFrame(sxModule, 'self::lcOpenAnswer2', t('answer'), {
+	configureAsFrame(sxModule, xq`self::lcOpenAnswer2`, t('answer'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the answer'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -337,16 +338,16 @@ export default function configureSxModule(sxModule) {
 
 	// lcOpenQuestion2
 	//     Use <lcOpenQuestion2> to pose an open-ended question in an assessment interaction.
-	configureAsFrame(sxModule, 'self::lcOpenQuestion2', t('open question'), {
+	configureAsFrame(sxModule, xq`self::lcOpenQuestion2`, t('open question'), {
 		contextualOperations: [{ name: ':contextual-delete-question' }],
-		titleQuery: './lcInteractionLabel2',
+		titleQuery: xq`./lcInteractionLabel2`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcQuestion2
 	//     Use the <lcQuestion2> element in an interaction to ask the question.
-	configureAsFrame(sxModule, 'self::lcQuestion2', t('question'), {
+	configureAsFrame(sxModule, xq`self::lcQuestion2`, t('question'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the question'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -355,12 +356,12 @@ export default function configureSxModule(sxModule) {
 	// lcSequence2
 	//     The <lcSequence2> element in an assessment interaction provides the position of a sequence option in
 	//     a sequence.
-	configureAsRemoved(sxModule, 'self::lcSequence2');
+	configureAsRemoved(sxModule, xq`self::lcSequence2`);
 
 	// lcSequenceOption2
 	//     The <lcSequenceOption2> element in an assessment interaction provides the contents of an item in a
 	//     sequence interaction.
-	configureAsFrame(sxModule, 'self::lcSequenceOption2', t('answer option'), {
+	configureAsFrame(sxModule, xq`self::lcSequenceOption2`, t('answer option'), {
 		contextualOperations: [
 			{ name: ':contextual-move-up-answer-option' },
 			{ name: ':contextual-move-down-answer-option' },
@@ -370,9 +371,9 @@ export default function configureSxModule(sxModule) {
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockBefore: [
 			createOrderingByAttributeWidget({
-				allItemsQuery: 'parent::lcSequenceOptionGroup2/lcSequenceOption2/lcSequence2',
+				allItemsQuery: xq`parent::lcSequenceOptionGroup2/lcSequenceOption2/lcSequence2`,
 				attributeLocalName: 'value',
-				currentItemQuery: 'child::lcSequence2',
+				currentItemQuery: xq`child::lcSequence2`,
 				icon: 'chevron-down',
 				popoverTitle: t('Correct position'),
 				tooltipContent: t(
@@ -387,7 +388,7 @@ export default function configureSxModule(sxModule) {
 	// The value is higher then the number of options
 	configureProperties(
 		sxModule,
-		'self::lcSequenceOption2[number(string(child::lcSequence2/@value)) gt count(parent::lcSequenceOptionGroup2/lcSequenceOption2)]',
+		xq`self::lcSequenceOption2[number(string(child::lcSequence2/@value)) gt count(parent::lcSequenceOptionGroup2/lcSequenceOption2)]`,
 		{
 			blockAfter: [
 				createIconWidget('exclamation-triangle', {
@@ -403,7 +404,7 @@ export default function configureSxModule(sxModule) {
 	// The value is not unique in the sequence
 	configureProperties(
 		sxModule,
-		'self::lcSequenceOption2[child::lcSequence2/@value = preceding-sibling::lcSequenceOption2/lcSequence2/@value or child::lcSequence2/@value = following-sibling::lcSequenceOption2/lcSequence2/@value]',
+		xq`self::lcSequenceOption2[child::lcSequence2/@value = preceding-sibling::lcSequenceOption2/lcSequence2/@value or child::lcSequence2/@value = following-sibling::lcSequenceOption2/lcSequence2/@value]`,
 		{
 			blockAfter: [
 				createIconWidget('exclamation-triangle', {
@@ -416,31 +417,31 @@ export default function configureSxModule(sxModule) {
 
 	// lcSequenceOptionGroup2
 	//     The <lcSequenceOptionGroup2> element provides the options for an assessment sequence interaction.
-	configureAsStructure(sxModule, 'self::lcSequenceOptionGroup2', t('sequence option group'));
+	configureAsStructure(sxModule, xq`self::lcSequenceOptionGroup2`, t('sequence option group'));
 
 	// lcSequencing2
 	//     An lcSequencing2 interaction asks the learner to arrange a list of choices into a predefined order,
 	//     such as small to large.
-	configureAsFrame(sxModule, 'self::lcSequencing2', t('sequencing question'), {
+	configureAsFrame(sxModule, xq`self::lcSequencing2`, t('sequencing question'), {
 		contextualOperations: [
 			{ name: ':contextual-move-up' },
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' }
 		],
-		titleQuery: './lcInteractionLabel2',
+		titleQuery: xq`./lcInteractionLabel2`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// lcSingleSelect2
 	//     An lcSingleSelect2 interaction presents three or more choices, only one of which is correct.
-	configureAsFrame(sxModule, 'self::lcSingleSelect2', t('single choice'), {
+	configureAsFrame(sxModule, xq`self::lcSingleSelect2`, t('single choice'), {
 		contextualOperations: [
 			{ name: ':contextual-move-up' },
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' }
 		],
-		titleQuery: './lcInteractionLabel2',
+		titleQuery: xq`./lcInteractionLabel2`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -448,13 +449,13 @@ export default function configureSxModule(sxModule) {
 	// lcTrueFalse2
 	//     A lcTrueFalse2 interaction presents the learner with two choices, one correct, the other incorrect,
 	//     often presented as true/false or yes/no responses.
-	configureAsFrame(sxModule, 'self::lcTrueFalse2', t('true/false choice'), {
+	configureAsFrame(sxModule, xq`self::lcTrueFalse2`, t('true/false choice'), {
 		contextualOperations: [
 			{ name: ':contextual-move-up' },
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' }
 		],
-		titleQuery: './lcInteractionLabel2',
+		titleQuery: xq`./lcInteractionLabel2`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/configureSxModule.js
@@ -309,9 +309,10 @@ export default function configureSxModule(sxModule) {
 
 	// lcMatchTable2
 	//     The <lcMatchTable2> element in an assessment interaction provides a format for matching items.
+	// TODO add xq to tabNavigationItemSelector when it has been implemented
 	configureAsStructure(sxModule, xq`self::lcMatchTable2`, t('match table'), {
 		tabNavigationItemSelector:
-			xq`name() = ("lcItem2", "lcMatchingItem2", "lcMatchingItemFeedback2")`
+			`name() = ("lcItem2", "lcMatchingItem2", "lcMatchingItemFeedback2")`
 	});
 
 	// lcMultipleSelect2

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/install.js
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/install.js
@@ -8,6 +8,7 @@ import evaluateXPathToFirstNode from 'fontoxml-selectors/src/evaluateXPathToFirs
 import evaluateXPathToStrings from 'fontoxml-selectors/src/evaluateXPathToStrings.js';
 import insertNodeAndRemoveFromSiblings from './api/insertNodeAndRemoveFromSiblingsCustomMutation.js';
 import replaceNodesWithMappedStructure from './api/replaceNodesWithMappedStructureCustomMutation.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function install() {
 	addCustomMutation('insert-node-and-remove-from-siblings', insertNodeAndRemoveFromSiblings);
@@ -68,19 +69,19 @@ export default function install() {
 
 			var lcInteractionNode;
 			var selectionAncestor = evaluateXPathToFirstNode(
-				'ancestor-or-self::*[self::section or self::lcSummary]',
+				xq`ancestor-or-self::*[self::section or self::lcSummary]`,
 				selectedElement,
 				readOnlyBlueprint
 			);
 			if (selectionAncestor) {
 				lcInteractionNode = evaluateXPathToFirstNode(
-					'preceding-sibling::lcInteraction[1]',
+					xq`preceding-sibling::lcInteraction[1]`,
 					selectionAncestor,
 					readOnlyBlueprint
 				);
 			} else {
 				lcInteractionNode = evaluateXPathToFirstNode(
-					'self::learningAssessmentbody/child::lcInteraction[last()]',
+					xq`self::learningAssessmentbody/child::lcInteraction[last()]`,
 					selectedElement,
 					readOnlyBlueprint
 				);

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/replaceBooktitleWithTitle.js
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/replaceBooktitleWithTitle.js
@@ -4,6 +4,7 @@ import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult.js
 import evaluateXPathToBoolean from 'fontoxml-selectors/src/evaluateXPathToBoolean.js';
 import evaluateXPathToFirstNode from 'fontoxml-selectors/src/evaluateXPathToFirstNode.js';
 import primitives from 'fontoxml-base-flow/src/primitives.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 const replaceBooktitleWithTitle = (argument, blueprint, format, _selection) => {
 	const booktitleNode = blueprint.lookup(argument.contextNodeId);
@@ -19,13 +20,13 @@ const replaceBooktitleWithTitle = (argument, blueprint, format, _selection) => {
 	}
 
 	const mainbooktitleNode = evaluateXPathToFirstNode(
-		'./child::mainbooktitle',
+		xq`./child::mainbooktitle`,
 		booktitleNode,
 		blueprint
 	);
 
 	bookTitleChildNodes.forEach(node => {
-		if (!evaluateXPathToBoolean('self::mainbooktitle', node, blueprint)) {
+		if (!evaluateXPathToBoolean(xq`self::mainbooktitle`, node, blueprint)) {
 			blueprint.removeChild(booktitleNode, node);
 		}
 	});

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/wrapAppendixElementsInAppendices.js
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/wrapAppendixElementsInAppendices.js
@@ -3,6 +3,7 @@ import blueprintQuery from 'fontoxml-blueprints/src/blueprintQuery.js';
 import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult.js';
 import evaluateXPathToNodes from 'fontoxml-selectors/src/evaluateXPathToNodes.js';
 import namespaceManager from 'fontoxml-dom-namespaces/src/namespaceManager.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 const wrapAppendixElementsInAppendices = (argument, blueprint) => {
 	const bookmapNode = blueprint.lookup(argument.contextNodeId);
@@ -11,7 +12,7 @@ const wrapAppendixElementsInAppendices = (argument, blueprint) => {
 		return CustomMutationResult.notAllowed();
 	}
 
-	const appendixNodes = evaluateXPathToNodes('./appendix', bookmapNode, blueprint);
+	const appendixNodes = evaluateXPathToNodes(xq`./appendix`, bookmapNode, blueprint);
 
 	if (!appendixNodes.length) {
 		return CustomMutationResult.notAllowed();

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/configureSxModule.js
@@ -9,6 +9,7 @@ import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNo
 import namespaceManager from 'fontoxml-dom-namespaces/src/namespaceManager.js';
 import registerCustomXPathFunction from 'fontoxml-selectors/src/registerCustomXPathFunction.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 import bookmapElementLabels from './api/bookmapElementLabels.js';
 
@@ -145,14 +146,14 @@ export default function configureSxModule(sxModule) {
 	//     The <abbrevlist> element references a list of abbreviations. It indicates to the processing software
 	//     that the author wants an abbreviation list generated at the particular location. Category: Bookmap
 	//     elements
-	configureAsRemoved(sxModule, 'self::abbrevlist', bookmapElementLabels.abbrevlist.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::abbrevlist`, bookmapElementLabels.abbrevlist.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::abbrevlist[not(@href)]',
+		xq`self::abbrevlist[not(@href)]`,
 		bookmapElementLabels.abbrevlist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
@@ -167,27 +168,27 @@ export default function configureSxModule(sxModule) {
 	//     The <amendments> element references a list of amendments or updates to the book. It indicates to the
 	//     processing software that the author wants an amendments list generated at the particular location.
 	//     Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::amendments', bookmapElementLabels.amendments.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::amendments`, bookmapElementLabels.amendments.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::amendments[not(@href)]',
+		xq`self::amendments[not(@href)]`,
 		bookmapElementLabels.amendments.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// appendices
 	//     The <appendices> element is an optional wrapper for <appendix> elements within a bookmap.
-	configureAsRemoved(sxModule, 'self::appendices', bookmapElementLabels.appendices.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::appendices`, bookmapElementLabels.appendices.markupLabel, {
 		contextualOperations: [
 			{
 				hideIn: ['context-menu', 'breadcrumbs-menu'],
@@ -202,7 +203,7 @@ export default function configureSxModule(sxModule) {
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::appendices[not(@href)]',
+		xq`self::appendices[not(@href)]`,
 		bookmapElementLabels.appendices.markupLabel,
 		{
 			contextualOperations: [
@@ -219,14 +220,14 @@ export default function configureSxModule(sxModule) {
 					[':contextual-unwrap-appendices--container']
 				])
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// appendix
 	//     The <appendix> element references a topic as an appendix within a book. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::appendix', bookmapElementLabels.appendix.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::appendix`, bookmapElementLabels.appendix.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups([
 			insertTopicOperations,
 			...convertToPlaceholderOrContainerOperations('container')
@@ -234,14 +235,14 @@ export default function configureSxModule(sxModule) {
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::appendix[not(@href)]',
+		xq`self::appendix[not(@href)]`,
 		bookmapElementLabels.appendix.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups([
 				insertTopicOperations,
 				...getPlaceholderOrContainerOperations('container')
 			]),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -249,7 +250,7 @@ export default function configureSxModule(sxModule) {
 	// approved
 	//     The <approved> element contains information about when and by whom the book was approved during its
 	//     publication history. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::approved', t('approved'));
+	configureAsRemoved(sxModule, xq`self::approved`, t('approved'));
 
 	// backmatter
 	//     The <backmatter> element contains the material that follows the main body of a document and any
@@ -257,7 +258,7 @@ export default function configureSxModule(sxModule) {
 	//     such as a glossary or an index. Category: Bookmap elements
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::backmatter',
+		xq`self::backmatter`,
 		bookmapElementLabels.backmatter.markupLabel,
 		{
 			contextualOperations: [
@@ -282,7 +283,7 @@ export default function configureSxModule(sxModule) {
 					hideIn: ['context-menu', 'breadcrumbs-menu']
 				}
 			],
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -292,20 +293,20 @@ export default function configureSxModule(sxModule) {
 	//     the processing software that the author wants a bibliography, containing links to related books,
 	//     articles, published papers, or other types of material, generated at the particular location.
 	//     Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::bibliolist', bookmapElementLabels.bibliolist.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::bibliolist`, bookmapElementLabels.bibliolist.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::bibliolist[not(@href)]',
+		xq`self::bibliolist[not(@href)]`,
 		bookmapElementLabels.bibliolist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -316,7 +317,7 @@ export default function configureSxModule(sxModule) {
 	//     evaluate the book's purpose. Category: Bookmap elements
 	configureAsRemoved(
 		sxModule,
-		'self::bookabstract',
+		xq`self::bookabstract`,
 		bookmapElementLabels.bookabstract.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
@@ -326,13 +327,13 @@ export default function configureSxModule(sxModule) {
 	);
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::bookabstract[not(@href)]',
+		xq`self::bookabstract[not(@href)]`,
 		bookmapElementLabels.bookabstract.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -341,30 +342,30 @@ export default function configureSxModule(sxModule) {
 	//     The <bookchangehistory> element contains information about the history of the book's creation and
 	//     publishing lifecycle, who wrote, reviewed, edited, and tested the book, and when these events took
 	//     place. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::bookchangehistory', t('book change history'));
+	configureAsRemoved(sxModule, xq`self::bookchangehistory`, t('book change history'));
 
 	// bookevent
 	//     The <bookevent> element indicates a general event in the publication history of a book. This is an
 	//     appropriate element for specialization if the current set of specific book event types, that is,
 	//     review, edit, test or approval, does not meed your needs. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::bookevent', t('book event'));
+	configureAsRemoved(sxModule, xq`self::bookevent`, t('book event'));
 
 	// bookeventtype
 	//     The <bookeventtype> element indicates the specific nature of a <bookevent>, such as updated,
 	//     indexed, or deprecated. The required name attribute indicates the event's type. Category: Bookmap
 	//     elements
-	configureAsRemoved(sxModule, 'self::bookeventtype', t('book event type'));
+	configureAsRemoved(sxModule, xq`self::bookeventtype`, t('book event type'));
 
 	// bookid
 	//     The <bookid> element contains the publisher's identification information for the book, such as part
 	//     number, edition number and ISBN number. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::bookid', t('book id'));
+	configureAsRemoved(sxModule, xq`self::bookid`, t('book id'));
 
 	// booklibrary
 	//     The <booklibrary> element contains the library information for a book. Library entries contain
 	//     information about the series, library, or collection of documents to which the book belongs.
 	//     Category: Bookmap elements
-	configureAsFrameWithBlock(sxModule, 'self::booklibrary', t('book library'), {
+	configureAsFrameWithBlock(sxModule, xq`self::booklibrary`, t('book library'), {
 		contextualOperations: [
 			{ name: ':contextual-delete-booklibrary', hideIn: ['structure-view'] }
 		],
@@ -379,20 +380,20 @@ export default function configureSxModule(sxModule) {
 	//     software that the author wants that list of topics generated at the particular location. For
 	//     example, it could be used in a specialization to reference the location of a list of program
 	//     listings or of authors of topics. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::booklist', bookmapElementLabels.booklist.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::booklist`, bookmapElementLabels.booklist.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::booklist[not(@href)]',
+		xq`self::booklist[not(@href)]`,
 		bookmapElementLabels.booklist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -406,7 +407,7 @@ export default function configureSxModule(sxModule) {
 
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::booklists',
+		xq`self::booklists`,
 		bookmapElementLabels.booklists.markupLabel,
 		{
 			contextualOperations: [
@@ -444,7 +445,7 @@ export default function configureSxModule(sxModule) {
 					]
 				}
 			],
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -452,7 +453,7 @@ export default function configureSxModule(sxModule) {
 	// bookmap
 	//     The <bookmap> element is a map file used to organize DITA content into a traditional book format.
 	//     Category: Bookmap elements
-	configureAsMapSheetFrame(sxModule, 'self::bookmap', bookmapElementLabels.bookmap.markupLabel, {
+	configureAsMapSheetFrame(sxModule, xq`self::bookmap`, bookmapElementLabels.bookmap.markupLabel, {
 		contextualOperations: [
 			{
 				contents: [
@@ -503,13 +504,13 @@ export default function configureSxModule(sxModule) {
 			}
 		],
 		defaultTextContainer: 'title',
-		titleQuery: `
+		titleQuery: xq`
 			let $title := if(./title) then ./title else ./booktitle/mainbooktitle
 			return $title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
-		visibleChildSelectorOrNodeSpec: 'self::title or self::booktitle',
+		visibleChildSelectorOrNodeSpec: xq`self::title or self::booktitle`,
 		blockFooter: [
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(name())]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(name())]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()],
@@ -517,52 +518,52 @@ export default function configureSxModule(sxModule) {
 	});
 
 	// title in map
-	configureAsTitleFrame(sxModule, 'self::title[parent::bookmap]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::bookmap]`, undefined, {
 		fontVariation: 'collection-title'
 	});
 
 	// bookmeta
 	//     The <bookmeta> element contains information about the book that is not considered book content, such
 	//     as copyright information, author information, and any classifications. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::bookmeta', t('book meta'));
+	configureAsRemoved(sxModule, xq`self::bookmeta`, t('book meta'));
 
 	// booknumber
 	//     The <booknumber> element contains the book's form number, such as SC21-1920. Category: Bookmap
 	//     elements
-	configureAsRemoved(sxModule, 'self::booknumber', t('book number'));
+	configureAsRemoved(sxModule, xq`self::booknumber`, t('book number'));
 
 	// bookowner
 	//     The <bookowner> element contains the owner of the copyright. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::bookowner', t('book owner'));
+	configureAsRemoved(sxModule, xq`self::bookowner`, t('book owner'));
 
 	// bookpartno
 	//     The <bookpartno> element contains the book's part number; such as 99F1234. This is generally the
 	//     number that the publisher uses to identify the book for tracking purposes. Category: Bookmap
 	//     elements
-	configureAsRemoved(sxModule, 'self::bookpartno', t('book part number'));
+	configureAsRemoved(sxModule, xq`self::bookpartno`, t('book part number'));
 
 	// bookrestriction
 	//     The <bookrestriction> element indicates whether the book is classified, or restricted in some way.
 	//     The value attribute indicates the restrictions; this may be a string like "All Rights Reserved,"
 	//     representing the publisher's copyright restrictions. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::bookrestriction', t('book restriction'));
+	configureAsRemoved(sxModule, xq`self::bookrestriction`, t('book restriction'));
 
 	// bookrights
 	//     The <bookrights> element contains the information about the legal rights associated with the book,
 	//     including copyright dates and owners. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::bookrights', t('book rights'));
+	configureAsRemoved(sxModule, xq`self::bookrights`, t('book rights'));
 
 	// booktitle
 	//     The <booktitle> element contains the title information for a book. , including <booklibrary> data, a
 	//     <maintitle> and subtitle (<titlealt>) as required. Category: Bookmap elements
-	configureAsFrame(sxModule, 'self::booktitle', t('book title'), {
+	configureAsFrame(sxModule, xq`self::booktitle`, t('book title'), {
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// booktitlealt
 	//     The <booktitlealt> element contains the alternative title, subtitle, or short title for a book.
 	//     Category: Bookmap elements
-	configureAsFrameWithBlock(sxModule, 'self::booktitlealt', t('alternative title'), {
+	configureAsFrameWithBlock(sxModule, xq`self::booktitlealt`, t('alternative title'), {
 		contextualOperations: [
 			{ name: ':contextual-delete-booktitlealt', hideIn: ['structure-view'] }
 		],
@@ -573,7 +574,7 @@ export default function configureSxModule(sxModule) {
 
 	// chapter
 	//     The <chapter> element references a topic as a chapter within a book. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::chapter', bookmapElementLabels.chapter.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::chapter`, bookmapElementLabels.chapter.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups([
 			insertTopicOperations,
 			...convertToPlaceholderOrContainerOperations('container')
@@ -581,14 +582,14 @@ export default function configureSxModule(sxModule) {
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::chapter[not(@href)]',
+		xq`self::chapter[not(@href)]`,
 		bookmapElementLabels.chapter.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups([
 				insertTopicOperations,
 				...getPlaceholderOrContainerOperations('container')
 			]),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -600,20 +601,20 @@ export default function configureSxModule(sxModule) {
 	//     materials and methods may also receive mention. In the case of technical books, a colophon may
 	//     specify the software used to prepare the text and diagrams for publication. Category: Bookmap
 	//     elements
-	configureAsRemoved(sxModule, 'self::colophon', bookmapElementLabels.colophon.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::colophon`, bookmapElementLabels.colophon.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::colophon[not(@href)]',
+		xq`self::colophon[not(@href)]`,
 		bookmapElementLabels.colophon.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -621,39 +622,39 @@ export default function configureSxModule(sxModule) {
 	// completed
 	//     The <completed> element indicates a completion date for some type of book event, such as a review,
 	//     editing, or testing. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::completed', t('completed'));
+	configureAsRemoved(sxModule, xq`self::completed`, t('completed'));
 
 	// copyrfirst
 	//     The <copyfirst> element contains the first copyright year within a multiyear copyright statement.
 	//     Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::copyrfirst', t('copyright year first'));
+	configureAsRemoved(sxModule, xq`self::copyrfirst`, t('copyright year first'));
 
 	// copyrlast
 	//     The <copylast> element contains the last copyright year within a multiyear copyright statement.
 	//     Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::copyrlast', t('copyright year last'));
+	configureAsRemoved(sxModule, xq`self::copyrlast`, t('copyright year last'));
 
 	// day
 	//     The <day> element denotes a day of the month. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::day', t('day'));
+	configureAsRemoved(sxModule, xq`self::day`, t('day'));
 
 	// dedication
 	//     The <dedication> element references a topic containing a dedication for the book, such as to a
 	//     person or group. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::dedication', bookmapElementLabels.dedication.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::dedication`, bookmapElementLabels.dedication.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::dedication[not(@href)]',
+		xq`self::dedication[not(@href)]`,
 		bookmapElementLabels.dedication.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -661,7 +662,7 @@ export default function configureSxModule(sxModule) {
 	// draftintro
 	//     The <draftintro> element references a topic used as an introduction to the draft of this book.
 	//     Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::draftintro', bookmapElementLabels.draftintro.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::draftintro`, bookmapElementLabels.draftintro.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups([
 			insertTopicOperations,
 			...convertToPlaceholderOrContainerOperations('container')
@@ -669,14 +670,14 @@ export default function configureSxModule(sxModule) {
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::draftintro[not(@href)]',
+		xq`self::draftintro[not(@href)]`,
 		bookmapElementLabels.draftintro.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups([
 				insertTopicOperations,
 				...getPlaceholderOrContainerOperations('container')
 			]),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -684,31 +685,31 @@ export default function configureSxModule(sxModule) {
 	// edited
 	//     The <edited> element contains information about when and by whom the book was edited during its
 	//     publication history. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::edited', t('edited'));
+	configureAsRemoved(sxModule, xq`self::edited`, t('edited'));
 
 	// edition
 	//     The <edition> element contains the edition number information, such as First Edition, or Third
 	//     Edition, used by a publisher to identify a book. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::edition', t('edition'));
+	configureAsRemoved(sxModule, xq`self::edition`, t('edition'));
 
 	// figurelist
 	//     The <figurelist> element references a list of figures in the book. It indicates to the processing
 	//     software that the author wants a list of figures generated at the particular location. Category:
 	//     Bookmap elements
-	configureAsRemoved(sxModule, 'self::figurelist', bookmapElementLabels.figurelist.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::figurelist`, bookmapElementLabels.figurelist.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::figurelist[not(@href)]',
+		xq`self::figurelist[not(@href)]`,
 		bookmapElementLabels.figurelist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -719,7 +720,7 @@ export default function configureSxModule(sxModule) {
 	//     <tablelist>, or <figurelist>. Category: Bookmap elements
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::frontmatter',
+		xq`self::frontmatter`,
 		bookmapElementLabels.frontmatter.markupLabel,
 		{
 			contextualOperations: [
@@ -750,7 +751,7 @@ export default function configureSxModule(sxModule) {
 					]
 				}
 			],
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -761,7 +762,7 @@ export default function configureSxModule(sxModule) {
 	//     Category: Bookmap elements
 	configureAsRemoved(
 		sxModule,
-		'self::glossarylist',
+		xq`self::glossarylist`,
 		bookmapElementLabels.glossarylist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups([
@@ -772,14 +773,14 @@ export default function configureSxModule(sxModule) {
 	);
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::glossarylist[not(@href)]',
+		xq`self::glossarylist[not(@href)]`,
 		bookmapElementLabels.glossarylist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups([
 				insertTopicOperations,
 				...getPlaceholderOrContainerOperations('container')
 			]),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -787,20 +788,20 @@ export default function configureSxModule(sxModule) {
 	// indexlist
 	//     The <indexlist> element lists the index entries in the book. It indicates to the processing software
 	//     that the author wants an index generated at the particular location. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::indexlist', bookmapElementLabels.indexlist.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::indexlist`, bookmapElementLabels.indexlist.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::indexlist[not(@href)]',
+		xq`self::indexlist[not(@href)]`,
 		bookmapElementLabels.indexlist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -808,12 +809,12 @@ export default function configureSxModule(sxModule) {
 	// isbn
 	//     The <isbn> element contains the book's International Standard Book Number (ISBN). Category: Bookmap
 	//     elements
-	configureAsRemoved(sxModule, 'self::isbn', t('isbn'));
+	configureAsRemoved(sxModule, xq`self::isbn`, t('isbn'));
 
 	// mainbooktitle
 	//     The <mainbooktitle> element contains the primary title information for a book. Category: Bookmap
 	//     elements
-	configureAsTitleFrame(sxModule, 'self::mainbooktitle', t('main book title'), {
+	configureAsTitleFrame(sxModule, xq`self::mainbooktitle`, t('main book title'), {
 		fontVariation: 'collection-title',
 		emptyElementPlaceholderText: t('type the book title')
 	});
@@ -821,16 +822,16 @@ export default function configureSxModule(sxModule) {
 	// maintainer
 	//     The <maintainer> element contains information about who maiintains the document; this can be an
 	//     organization or a person. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::maintainer', t('maintainer'));
+	configureAsRemoved(sxModule, xq`self::maintainer`, t('maintainer'));
 
 	// month
 	//     The <month> element denotes a month of the year. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::month', t('month'));
+	configureAsRemoved(sxModule, xq`self::month`, t('month'));
 
 	// notices
 	//     The <notices> element references special notice information, for example, legal notices about
 	//     supplementary copyrights and trademarks associated with the book. . Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::notices', bookmapElementLabels.notices.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::notices`, bookmapElementLabels.notices.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups([
 			insertTopicOperations,
 			...convertToPlaceholderOrContainerOperations('container')
@@ -838,14 +839,14 @@ export default function configureSxModule(sxModule) {
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::notices[not(@href)]',
+		xq`self::notices[not(@href)]`,
 		bookmapElementLabels.notices.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups([
 				insertTopicOperations,
 				...getPlaceholderOrContainerOperations('container')
 			]),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -855,14 +856,14 @@ export default function configureSxModule(sxModule) {
 	//     <organizationname>, the <organization> element is not restricted to usage within
 	//     <authorinformation>; it does not have to contain the name of an authoring organization. Category:
 	//     Bookmap elements
-	configureAsRemoved(sxModule, 'self::organization', t('organization'));
+	configureAsRemoved(sxModule, xq`self::organization`, t('organization'));
 
 	// part
 	//     The <part> element references a part topic for the book. A new part is started. Use <part> to divide
 	//     a document's chapters into logical groupings. For example, in a document that contains both guide
 	//     and reference information, you can define two parts, one containing the guide information and the
 	//     other containing the reference information. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::part', bookmapElementLabels.part.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::part`, bookmapElementLabels.part.markupLabel, {
 		contextualOperations: [
 			{
 				hideIn: ['context-menu', 'breadcrumbs-menu'],
@@ -884,7 +885,7 @@ export default function configureSxModule(sxModule) {
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::part[not(@href)]',
+		xq`self::part[not(@href)]`,
 		bookmapElementLabels.part.markupLabel,
 		{
 			contextualOperations: [
@@ -905,7 +906,7 @@ export default function configureSxModule(sxModule) {
 					getPlaceholderOrContainerOperations('container')
 				)
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -914,12 +915,12 @@ export default function configureSxModule(sxModule) {
 	//     The <person> element contains information about the name of a person. Note that unlike the
 	//     <personname> element, the <person> element is not restricted to describing the names of authors.
 	//     Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::person', t('person'));
+	configureAsRemoved(sxModule, xq`self::person`, t('person'));
 
 	// preface
 	//     The <preface> element references introductory information about a book, such as the purpose and
 	//     structure of the document. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::preface', bookmapElementLabels.preface.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::preface`, bookmapElementLabels.preface.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups([
 			insertTopicOperations,
 			...convertToPlaceholderOrContainerOperations('container')
@@ -927,14 +928,14 @@ export default function configureSxModule(sxModule) {
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::preface[not(@href)]',
+		xq`self::preface[not(@href)]`,
 		bookmapElementLabels.preface.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups([
 				insertTopicOperations,
 				...getPlaceholderOrContainerOperations('container')
 			]),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -942,64 +943,64 @@ export default function configureSxModule(sxModule) {
 	// printlocation
 	//     The <printlocation> element indicates the location where the book was printed. Customarily, the
 	//     content is restricted to the name of the country. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::printlocation', t('print location'));
+	configureAsRemoved(sxModule, xq`self::printlocation`, t('print location'));
 
 	// published
 	//     The <published> element contains information about the person or organization publishing the book,
 	//     the dates when it was started and completed, and any special restrictions associated with it.
 	//     Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::published', t('published'));
+	configureAsRemoved(sxModule, xq`self::published`, t('published'));
 
 	// publisherinformation
 	//     The <publisherinformation> contains information about what group or person published the book, where
 	//     it was published, and certain details about its publication history. Other publication history
 	//     information is found in the <bookchangehistory> element. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::publisherinformation', t('publisher information'));
+	configureAsRemoved(sxModule, xq`self::publisherinformation`, t('publisher information'));
 
 	// publishtype
 	//     The <publishtype> element indicates whether the book is generally available or is restricted in some
 	//     way. The value attribute indicates the restrictions. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::publishtype', t('publish type'));
+	configureAsRemoved(sxModule, xq`self::publishtype`, t('publish type'));
 
 	// reviewed
 	//     The <reviewed> element contains information about when and by whom the book was reviewed during its
 	//     publication history. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::reviewed', t('reviewed'));
+	configureAsRemoved(sxModule, xq`self::reviewed`, t('reviewed'));
 
 	// revisionid
 	//     The <revisionid> element indicates the revision number or revision ID of the book. The processing
 	//     implementation determines how the level is displayed. Common methods include using a dash, for
 	//     example "-01". or a period, such as ".01". Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::revisionid', t('revision id'));
+	configureAsRemoved(sxModule, xq`self::revisionid`, t('revision id'));
 
 	// started
 	//     The <started> element indicates a start date for some type of book event, such as a review, editing,
 	//     or testing. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::started', t('started'));
+	configureAsRemoved(sxModule, xq`self::started`, t('started'));
 
 	// summary
 	//     The <summary> element contains a text summary associated with a book event (such as <approved> or
 	//     <reviewed>) or with the list of copyrights for the book. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::summary', t('summary'));
+	configureAsRemoved(sxModule, xq`self::summary`, t('summary'));
 
 	// tablelist
 	//     The <tablelist> element references a list of tables within the book. It indicates to the processing
 	//     software that the author wants a list of tables generated at the particular location. Category:
 	//     Bookmap elements
-	configureAsRemoved(sxModule, 'self::tablelist', bookmapElementLabels.tablelist.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::tablelist`, bookmapElementLabels.tablelist.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::tablelist[not(@href)]',
+		xq`self::tablelist[not(@href)]`,
 		bookmapElementLabels.tablelist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -1007,26 +1008,26 @@ export default function configureSxModule(sxModule) {
 	// tested
 	//     The <tested> element contains information about when and by whom the book was tested during its
 	//     publication history. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::tested', t('tested'));
+	configureAsRemoved(sxModule, xq`self::tested`, t('tested'));
 
 	// toc
 	//     The <toc> element references the table of contents within the book. It indicates to the processing
 	//     software that the author wants a table of contents generated at the particular location. Category:
 	//     Bookmap elements
-	configureAsRemoved(sxModule, 'self::toc', bookmapElementLabels.toc.markupLabel, {
+	configureAsRemoved(sxModule, xq`self::toc`, bookmapElementLabels.toc.markupLabel, {
 		contextualOperations: formatContextualOperationListWithGroups(
 			convertToPlaceholderOrContainerOperations('placeholder')
 		)
 	});
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::toc[not(@href)]',
+		xq`self::toc[not(@href)]`,
 		bookmapElementLabels.toc.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
@@ -1037,7 +1038,7 @@ export default function configureSxModule(sxModule) {
 	//     Category: Bookmap elements
 	configureAsRemoved(
 		sxModule,
-		'self::trademarklist',
+		xq`self::trademarklist`,
 		bookmapElementLabels.trademarklist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
@@ -1047,22 +1048,22 @@ export default function configureSxModule(sxModule) {
 	);
 	configureAsMapSheetFrame(
 		sxModule,
-		'self::trademarklist[not(@href)]',
+		xq`self::trademarklist[not(@href)]`,
 		bookmapElementLabels.trademarklist.markupLabel,
 		{
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// volume
 	//     The <volume> element contains the book's volume number, such as Volume 2. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::volume', t('volume'));
+	configureAsRemoved(sxModule, xq`self::volume`, t('volume'));
 
 	// year
 	//     The <year> element denotes a year. Category: Bookmap elements
-	configureAsRemoved(sxModule, 'self::year', t('year'));
+	configureAsRemoved(sxModule, xq`self::year`, t('year'));
 }

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/install.js
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/install.js
@@ -10,6 +10,7 @@ import readOnlyBlueprint from 'fontoxml-blueprints/src/readOnlyBlueprint.js';
 import replaceTitleWithBooktitle from './api/replaceTitleWithBooktitle.js';
 import replaceBooktitleWithTitle from './api/replaceBooktitleWithTitle.js';
 import wrapAppendixElementsInAppendices from './api/wrapAppendixElementsInAppendices.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 function isDocumentAMapPromise(stepData) {
 	const remoteDocumentId = stepData.selectedDocumentTemplateId || stepData.remoteDocumentId;
@@ -26,7 +27,7 @@ function isDocumentAMapPromise(stepData) {
 
 		if (
 			evaluateXPathToBoolean(
-				'fonto:dita-class(., "map/map")',
+				xq`fonto:dita-class(., "map/map")`,
 				documentNode.documentElement,
 				readOnlyBlueprint
 			)

--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureImageWithoutPermanentId.js
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureImageWithoutPermanentId.js
@@ -1,5 +1,6 @@
 import configureAsImageInFrame from 'fontoxml-families/src/configureAsImageInFrame.js';
 import configureAsInlineImageInFrame from 'fontoxml-families/src/configureAsInlineImageInFrame.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 // This file removes the permanentId which is the other way around then for cross reference,
 // for compatability reasons.
@@ -7,19 +8,19 @@ export default function configureImageWithoutPermanentId(sxModule) {
 	// To disable permanentId's in images (also known as the reference pipeline), set
 	// isPermanentId to false.
 
-	configureAsImageInFrame(sxModule, 'self::image', undefined, {
+	configureAsImageInFrame(sxModule, xq`self::image`, undefined, {
 		priority: 2,
-		referenceQuery: '@href',
+		referenceQuery: xq`@href`,
 		isPermanentId: false
 	});
 
 	configureAsInlineImageInFrame(
 		sxModule,
-		'self::image and fonto:in-inline-layout(.)',
+		xq`self::image and fonto:in-inline-layout(.)`,
 		undefined,
 		{
 			priority: 2,
-			referenceQuery: '@href',
+			referenceQuery: xq`@href`,
 			isPermanentId: false,
 			defaultTextContainer: {
 				localName: 'alt',

--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.js
@@ -140,9 +140,10 @@ export default function configureSxModule(sxModule) {
 	//     A definition list (<dl>) is a list of terms and corresponding definitions. The term (<dt>) is
 	//     usually flush left. The description or definition (<dd>) is usually either indented and on the next
 	//     line, or on the same line to the right of the term. Category: Body elements
+	// TODO add xq to tabNavigationItemSelector when it has been implemented
 	configureAsFrame(sxModule, xq`self::dl`, t('definition table'), {
 		contextualOperations: [{ name: ':contextual-delete-dl' }],
-		tabNavigationItemSelector: xq`self::dthd or self::ddhd or self::dt or self::dd`,
+		tabNavigationItemSelector: `self::dthd or self::ddhd or self::dt or self::dd`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -583,9 +584,10 @@ export default function configureSxModule(sxModule) {
 		showSelectionWidget: true
 	});
 
+	// TODO add xq to tabNavigationItemSelector when it has been implemented
 	configureProperties(sxModule, xq`self::simpletable`, {
 		markupLabel: t('simple table'),
-		tabNavigationItemSelector: xq`self::stentry`,
+		tabNavigationItemSelector: `self::stentry`,
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 

--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.js
@@ -21,6 +21,7 @@ import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMe
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import configureAsListElements from 'fontoxml-list-flow/src/configureAsListElements.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// alt
@@ -28,14 +29,14 @@ export default function configureSxModule(sxModule) {
 	//     image element; the attribute is deprecated, so the alt element should be used instead. As an
 	//     element, alt provides direct text entry within an XML editor and is more easily accessed than an
 	//     attribute for translation. Category: Body elements
-	configureAsFrameWithBlock(sxModule, 'self::alt', t('alternative text'), {
+	configureAsFrameWithBlock(sxModule, xq`self::alt`, t('alternative text'), {
 		emptyElementPlaceholderText: t('type the alternative text'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	configureAsInlineStructure(
 		sxModule,
-		'self::alt and parent::image[fonto:in-inline-layout(.)]',
+		xq`self::alt and parent::image[fonto:in-inline-layout(.)]`,
 		t('alternative text')
 	);
 
@@ -44,12 +45,12 @@ export default function configureSxModule(sxModule) {
 	//     true or false, high or low, and so forth. The element itself is empty; the value of the element is
 	//     stored in its state attribute, and the semantic associated with the value is typically in a
 	//     specialized name derived from this element. Category: Specialization elements
-	configureAsRemoved(sxModule, 'self::boolean', t('boolean'));
+	configureAsRemoved(sxModule, xq`self::boolean`, t('boolean'));
 
 	// cite
 	//     The <cite> element is used when you need a bibliographic citation that refers to a book or article.
 	//     It specifically identifies the title of the resource. Category: Body elements
-	configureAsInlineFrame(sxModule, 'self::cite', t('citation'));
+	configureAsInlineFrame(sxModule, xq`self::cite`, t('citation'));
 
 	// data
 	//     The <data> element represents a property within a DITA topic or map. While the <data> element can be
@@ -57,7 +58,7 @@ export default function configureSxModule(sxModule) {
 	//     Default processing treats the property values as an unknown kind of metadata, but custom processing
 	//     can match the name attribute or specialized element to format properties as sidebars or other
 	//     adornments or to harvest properties for automated processing. Category: Miscellaneous elements
-	configureAsRemoved(sxModule, 'self::data', t('data'));
+	configureAsRemoved(sxModule, xq`self::data`, t('data'));
 
 	// data-about
 	//     The <data-about> element identifies the subject of a property when the subject isn't associated with
@@ -66,19 +67,19 @@ export default function configureSxModule(sxModule) {
 	//     somewhere other than inside the actual subject of the property. The <data-about> element is
 	//     particularly useful as a basis for specialization in combination with the <data> element. Category:
 	//     Miscellaneous elements
-	configureAsRemoved(sxModule, 'self::data-about', t('data-about'));
+	configureAsRemoved(sxModule, xq`self::data-about`, t('data-about'));
 
 	// dd
 	//     The definition description (<dd>) element contains the description of a term in a definition list
 	//     entry. Category: Body elements
-	configureAsStructure(sxModule, 'self::dd', t('definition'), {
+	configureAsStructure(sxModule, xq`self::dd`, t('definition'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the definition')
 	});
 
 	configureAsFrame(
 		sxModule,
-		'self::dd and count(preceding-sibling::* | following-sibling::*) > 1',
+		xq`self::dd and count(preceding-sibling::* | following-sibling::*) > 1`,
 		t('definition'),
 		{
 			defaultTextContainer: 'p',
@@ -90,7 +91,7 @@ export default function configureSxModule(sxModule) {
 	// p in dd
 	configureAsBlock(
 		sxModule,
-		'self::p[parent::dd] and not(preceding-sibling::* or following-sibling::*)',
+		xq`self::p[parent::dd] and not(preceding-sibling::* or following-sibling::*)`,
 		t('paragraph'),
 		{
 			emptyElementPlaceholderText: t('type the definition')
@@ -100,7 +101,7 @@ export default function configureSxModule(sxModule) {
 	// ddhd
 	//     The definition descriptions heading (<ddhd>) element contains an optional heading or title for a
 	//     column of descriptions or definitions in a definition list. Category: Body elements
-	configureAsBlock(sxModule, 'self::ddhd', t('definitions title'), {
+	configureAsBlock(sxModule, xq`self::ddhd`, t('definitions title'), {
 		emptyElementPlaceholderText: t('type the title for the definitions')
 	});
 
@@ -110,7 +111,7 @@ export default function configureSxModule(sxModule) {
 	//     xref/link, it provides a description of the target; processors that support it may choose to display
 	//     this as hover help. In object, it contains alternate content for use when in contexts that cannot
 	//     display the object. Category: Body elements
-	configureAsFrame(sxModule, 'self::desc', t('description'), {
+	configureAsFrame(sxModule, xq`self::desc`, t('description'), {
 		emptyElementPlaceholderText: t('type the description'),
 		defaultTextContainer: 'p',
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -119,7 +120,7 @@ export default function configureSxModule(sxModule) {
 	// p in desc
 	configureProperties(
 		sxModule,
-		'self::p[parent::desc] and not(preceding-sibling::* or following-sibling::*)',
+		xq`self::p[parent::desc] and not(preceding-sibling::* or following-sibling::*)`,
 		{
 			emptyElementPlaceholderText: t('type the definition')
 		}
@@ -127,7 +128,7 @@ export default function configureSxModule(sxModule) {
 
 	// div
 	//     Category: Body elements
-	configureAsFrame(sxModule, 'self::div', t('division'), {
+	configureAsFrame(sxModule, xq`self::div`, t('division'), {
 		contextualOperations: [{ name: ':contextual-unwrap-div' }],
 		emptyElementPlaceholderText: t('type the content'),
 		defaultTextContainer: 'p',
@@ -139,9 +140,9 @@ export default function configureSxModule(sxModule) {
 	//     A definition list (<dl>) is a list of terms and corresponding definitions. The term (<dt>) is
 	//     usually flush left. The description or definition (<dd>) is usually either indented and on the next
 	//     line, or on the same line to the right of the term. Category: Body elements
-	configureAsFrame(sxModule, 'self::dl', t('definition table'), {
+	configureAsFrame(sxModule, xq`self::dl`, t('definition table'), {
 		contextualOperations: [{ name: ':contextual-delete-dl' }],
-		tabNavigationItemSelector: 'self::dthd or self::ddhd or self::dt or self::dd',
+		tabNavigationItemSelector: xq`self::dthd or self::ddhd or self::dt or self::dd`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -150,8 +151,8 @@ export default function configureSxModule(sxModule) {
 	//     In a definition list, each list item is defined by the definition list entry (<dlentry>) element.
 	//     The definition list entry element includes a term <dt> and one or more definitions or descriptions
 	//     <dd> of that term. Category: Body elements
-	configureAsDefinitionsTableRow(sxModule, 'self::dlentry', t('row'), {
-		columns: [{ query: './dt', width: 1 }, { query: './dd', width: 2 }],
+	configureAsDefinitionsTableRow(sxModule, xq`self::dlentry`, t('row'), {
+		columns: [{ query: xq`./dt`, width: 1 }, { query: xq`./dd`, width: 2 }],
 		contextualOperations: [
 			{ name: ':dlentry-insert-dt', hideIn: ['breadcrumbs-menu'] },
 			{ name: ':dlentry-insert-dd', hideIn: ['breadcrumbs-menu'] },
@@ -166,8 +167,8 @@ export default function configureSxModule(sxModule) {
 	//     The <dlhead> element contains optional headings for the term and description columns in a definition
 	//     list. The definition list heading contains a heading <dthd> for the column of terms and an optional
 	//     heading <ddhd>for the column of descriptions. Category: Body elements
-	configureAsDefinitionsTableRow(sxModule, 'self::dlhead', t('header'), {
-		columns: [{ query: './dthd', width: 1 }, { query: './ddhd', width: 2 }],
+	configureAsDefinitionsTableRow(sxModule, xq`self::dlhead`, t('header'), {
+		columns: [{ query: xq`./dthd`, width: 1 }, { query: xq`./ddhd`, width: 2 }],
 		contextualOperations: [{ name: ':contextual-delete-dlhead' }],
 		borders: true,
 		backgroundColor: 'black',
@@ -179,17 +180,17 @@ export default function configureSxModule(sxModule) {
 	//     marked-up content. Use the <draft-comment> element to ask a question or make a comment that you
 	//     would like others to review. To indicate the source of the draft comment or the status of the
 	//     comment, use the author, time or disposition attributes. Category: Miscellaneous elements
-	configureAsRemoved(sxModule, 'self::draft-comment', t('comment'));
+	configureAsRemoved(sxModule, xq`self::draft-comment`, t('comment'));
 
 	// dt
 	//     The definition term <dt> element contains a term in a definition list entry. Category: Body elements
-	configureAsBlock(sxModule, 'self::dt', t('term'), {
+	configureAsBlock(sxModule, xq`self::dt`, t('term'), {
 		emptyElementPlaceholderText: t('type the term')
 	});
 	// dt which is not the only dt in dlentry
 	configureAsFrameWithBlock(
 		sxModule,
-		'self::dt and count(preceding-sibling::* | following-sibling::*) > 1',
+		xq`self::dt and count(preceding-sibling::* | following-sibling::*) > 1`,
 		t('term'),
 		{
 			showWhen: 'has-focus'
@@ -199,7 +200,7 @@ export default function configureSxModule(sxModule) {
 	// dthd
 	//     The definition term heading (<dthd>) element is contained in a definition list head (<dlhead>) and
 	//     provides an optional heading for the column of terms in a description list. Category: Body elements
-	configureAsBlock(sxModule, 'self::dthd', t('terms title'), {
+	configureAsBlock(sxModule, xq`self::dthd`, t('terms title'), {
 		emptyElementPlaceholderText: t('type the title for the terms')
 	});
 
@@ -208,7 +209,7 @@ export default function configureSxModule(sxModule) {
 	//     for a wide variety of content. Most commonly, the figure element contains an image element (a
 	//     graphic or artwork), but it can contain several kinds of text objects as well. A title is placed
 	//     inside the figure element to provide a caption to describe the content. Category: Body elements
-	configureAsFrame(sxModule, 'self::fig', t('figure'), {
+	configureAsFrame(sxModule, xq`self::fig`, t('figure'), {
 		contextualOperations: [
 			{ name: ':fig-insert-title' },
 			{ name: ':fig-insert-desc' },
@@ -216,7 +217,7 @@ export default function configureSxModule(sxModule) {
 			{ name: ':fig-insert-image', hideIn: ['element-menu', 'breadcrumbs-menu'] },
 			{ name: ':contextual-delete-fig' }
 		],
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -232,7 +233,7 @@ export default function configureSxModule(sxModule) {
 	);
 
 	// title in fig
-	configureAsTitleFrame(sxModule, 'self::title[parent::fig]', t('title'), {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::fig]`, t('title'), {
 		fontVariation: 'figure-title'
 	});
 
@@ -241,12 +242,12 @@ export default function configureSxModule(sxModule) {
 	//     contain multiple cross-references, footnotes or keywords, but not multipart images. Multipart images
 	//     in DITA should be represented by a suitable media type displayed by the <object> element. Category:
 	//     Body elements
-	configureAsRemoved(sxModule, 'self::figgroup', t('figure group'));
+	configureAsRemoved(sxModule, xq`self::figgroup`, t('figure group'));
 
 	// fn
 	//     Use footnote (<fn>) to annotate text with notes that are not appropriate for inclusion in line or to
 	//     indicate the source for facts or other material used in the text. Category: Miscellaneous elements
-	configureAsFrame(sxModule, 'self::fn', t('footnote'), {
+	configureAsFrame(sxModule, xq`self::fn`, t('footnote'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the footnote'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -254,7 +255,7 @@ export default function configureSxModule(sxModule) {
 
 	configureAsInlineAnchorToStructure(
 		sxModule,
-		'self::fn and not(@conref) and fonto:in-inline-layout(.)',
+		xq`self::fn and not(@conref) and fonto:in-inline-layout(.)`,
 		t('footnote'),
 		{
 			defaultTextContainer: 'p',
@@ -268,7 +269,7 @@ export default function configureSxModule(sxModule) {
 	// p in fn
 	configureAsBlock(
 		sxModule,
-		'self::p[parent::fn] and not(preceding-sibling::* or following-sibling::*)',
+		xq`self::p[parent::fn] and not(preceding-sibling::* or following-sibling::*)`,
 		t('paragraph'),
 		{
 			emptyElementPlaceholderText: t('type the footnote')
@@ -282,7 +283,7 @@ export default function configureSxModule(sxModule) {
 	//     Specialization of <foreign> should be implemented as a domain, but for those looking for more
 	//     control over the content can implement foreign vocabulary as an element specialization. Category:
 	//     Specialization elements
-	configureAsRemoved(sxModule, 'self::foreign', t('foreign'));
+	configureAsRemoved(sxModule, xq`self::foreign`, t('foreign'));
 
 	// image
 	//     Include artwork or images in a DITA topic by using the <image> element. The <image> element has
@@ -293,15 +294,15 @@ export default function configureSxModule(sxModule) {
 	//     allows the output formatting processor to bring the image into the text flow. To make the intent of
 	//     the image more accessible for users using screen readers or text-only readers, always include a
 	//     description of the image's content in the alt element. Category: Body elements
-	configureAsImageInFrame(sxModule, 'self::image', t('image'), {
+	configureAsImageInFrame(sxModule, xq`self::image`, t('image'), {
 		contextualOperations: [{ name: ':contextual-edit-image' }, { name: ':image-insert-alt' }],
-		referenceQuery: '@href',
+		referenceQuery: xq`@href`,
 		isPermanentId: true
 	});
 
 	configureAsInlineImageInFrame(
 		sxModule,
-		'self::image and fonto:in-inline-layout(.)',
+		xq`self::image and fonto:in-inline-layout(.)`,
 		t('inline image'),
 		{
 			defaultTextContainer: {
@@ -310,7 +311,7 @@ export default function configureSxModule(sxModule) {
 				insert: 'always',
 				implicit: 'inline',
 			},
-			referenceQuery: '@href',
+			referenceQuery: xq`@href`,
 			isPermanentId: true,
 		}
 	);
@@ -319,12 +320,12 @@ export default function configureSxModule(sxModule) {
 	//     The <index-base> element allows indexing extensions to be added by specializing off this element. It
 	//     does not in itself have any meaning and should be ignored in processing. Category: Miscellaneous
 	//     elements
-	configureAsRemoved(sxModule, 'self::index-base', t('index-base'));
+	configureAsRemoved(sxModule, xq`self::index-base`, t('index-base'));
 
 	// indexterm
 	//     An <indexterm> element allows the author to indicate that a certain word or phrase should produce an
 	//     index entry in the generated index. Category: Miscellaneous elements
-	configureAsInlineFrame(sxModule, 'self::indexterm', t('index term'), {
+	configureAsInlineFrame(sxModule, xq`self::indexterm`, t('index term'), {
 		emptyElementPlaceholderText: t('type the index term'),
 		backgroundColor: 'blue'
 	});
@@ -332,19 +333,19 @@ export default function configureSxModule(sxModule) {
 	// indextermref
 	//     This element is not completely defined, and is reserved for future use. Category: Miscellaneous
 	//     elements
-	configureAsRemoved(sxModule, 'self::indextermref', t('indextermref'));
+	configureAsRemoved(sxModule, xq`self::indextermref`, t('indextermref'));
 
 	// itemgroup
 	//     The <itemgroup> element is reserved for use in specializations of DITA. As a container element, it
 	//     can be used to sub-divide or organize elements that occur inside a list item, definition, or
 	//     parameter definition. Category: Specialization elements
-	configureAsRemoved(sxModule, 'self::itemgroup', t('itemgroup'));
+	configureAsRemoved(sxModule, xq`self::itemgroup`, t('itemgroup'));
 
 	// keyword
 	//     The <keyword> element identifies a keyword or token, such as a single value from an enumerated list,
 	//     the name of a command or parameter, product name, or a lookup key for a message. Category: Body
 	//     elements
-	configureAsInlineFrame(sxModule, 'self::keyword', t('keyword'), {
+	configureAsInlineFrame(sxModule, xq`self::keyword`, t('keyword'), {
 		backgroundColor: 'blue'
 	});
 
@@ -353,7 +354,7 @@ export default function configureSxModule(sxModule) {
 	//     formatted for output, numbers and alpha characters are usually output with list items in ordered
 	//     lists, while bullets and dashes are usually output with list items in unordered lists. Category:
 	//     Body elements
-	configureProperties(sxModule, 'self::li', {
+	configureProperties(sxModule, xq`self::li`, {
 		contextualOperations: [
 			{ name: ':contextual-insert-li--above' },
 			{ name: ':contextual-insert-li--below' }
@@ -365,7 +366,7 @@ export default function configureSxModule(sxModule) {
 	//     The <lines> element may be used to represent dialogs, lists, text fragments, and so forth. The
 	//     <lines> element is similar to <pre> in that hard line breaks are preserved, but the font style is
 	//     not set to monospace, and extra spaces inside the lines are not preserved. Category: Body elements
-	configureAsGroupWithBlock(sxModule, 'self::lines', t('text with line breaks'), {
+	configureAsGroupWithBlock(sxModule, xq`self::lines`, t('text with line breaks'), {
 		expression: 'compact',
 		withNewlineBreakToken: true
 	});
@@ -373,21 +374,21 @@ export default function configureSxModule(sxModule) {
 	// longdescref
 	//     A reference to a textual description of the graphic or object. This element is a replacement for the
 	//     longdescref attribute on image and object elements.
-	configureAsRemoved(sxModule, 'self::longdescref', t('longdescref'));
+	configureAsRemoved(sxModule, xq`self::longdescref`, t('longdescref'));
 
 	// longquoteref
 	//     The <longquoteref> element provides a reference to the source of a long quote. The long quote (<lq>)
 	//     element itself allows an href attribute to specify the source of a quote, but it does not allow
 	//     other standard linking attributes such as keyref, scope, and format. The <longquoteref> element
 	//     should be used for references that make use of these attributes.
-	configureAsInlineObject(sxModule, 'self::longquoteref', t('source'));
+	configureAsInlineObject(sxModule, xq`self::longquoteref`, t('source'));
 
 	// lq
 	//     The long quote (<lq>) element indicates content quoted from another source. Use the quote element
 	//     <q> for short, inline quotations, and long quote <lq> for quotations that are too long for inline
 	//     use, following normal guidelines for quoting other sources. You can store a URL to the source of the
 	//     quotation in the href attribute; the href value may point to a DITA topic. Category: Body elements
-	configureAsFrame(sxModule, 'self::lq', t('long quote'), {
+	configureAsFrame(sxModule, xq`self::lq`, t('long quote'), {
 		contextualOperations: [{ name: ':contextual-unwrap-lq' }],
 		defaultTextContainer: 'p',
 		blockHeaderLeft: [createMarkupLabelWidget()],
@@ -400,9 +401,9 @@ export default function configureSxModule(sxModule) {
 	//     shows in the main browser window. Use <navtitle> when the actual title of the topic isn't
 	//     appropriate for use in navigation panes or online contents (for example, because the actual title is
 	//     too long). Category: Topic elements
-	configureAsRemoved(sxModule, 'self::navtitle', t('navigation title'));
+	configureAsRemoved(sxModule, xq`self::navtitle`, t('navigation title'));
 
-	configureAsFrameWithBlock(sxModule, 'self::navtitle[parent::titlealts]', undefined, {
+	configureAsFrameWithBlock(sxModule, xq`self::navtitle[parent::titlealts]`, undefined, {
 		emptyElementPlaceholderText: t('type the navigation title'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -477,7 +478,7 @@ export default function configureSxModule(sxModule) {
 		}).concat([{ name: ':contextual-unwrap-note' }]);
 	}
 
-	configureAsFrame(sxModule, 'self::note', t('note'), {
+	configureAsFrame(sxModule, xq`self::note`, t('note'), {
 		contextualOperations: getContextualOperationsForNoteType('@type=null'),
 		defaultTextContainer: 'p',
 		blockHeaderLeft: [createMarkupLabelWidget()],
@@ -486,7 +487,7 @@ export default function configureSxModule(sxModule) {
 
 	Object.keys(NOTE_VISUALIZATION_BY_TYPE).forEach(function(noteType) {
 		const noteVisualization = NOTE_VISUALIZATION_BY_TYPE[noteType];
-		configureProperties(sxModule, 'self::note[@type="' + noteType + '"]', {
+		configureProperties(sxModule, xq`self::note[@type="${noteType}"]`, {
 			markupLabel: noteVisualization.label,
 			contextualOperations: getContextualOperationsForNoteType(noteType),
 			backgroundColor: noteVisualization.backgroundColor
@@ -495,22 +496,22 @@ export default function configureSxModule(sxModule) {
 
 	// object
 	//     DITA's <object> element corresponds to the HTML <object> element. Category: Body elements
-	configureAsRemoved(sxModule, 'self::object', t('object'));
+	configureAsRemoved(sxModule, xq`self::object`, t('object'));
 
 	// ol
 	// li in ol
 	// p in li in ol
-	configureMarkupLabel(sxModule, 'self::ol', t('numbered list'));
-	configureContextualOperations(sxModule, 'self::ol', [{ name: ':ol-convert-to-ul' }]);
+	configureMarkupLabel(sxModule, xq`self::ol`, t('numbered list'));
+	configureContextualOperations(sxModule, xq`self::ol`, [{ name: ':ol-convert-to-ul' }]);
 
 	configureAsListElements(sxModule, {
 		list: {
-			selector: 'self::ol',
+			selector: xq`self::ol`,
 			style: configureAsListElements.NUMBERED_LIST_STYLE,
 			nodeName: 'ol'
 		},
 		item: {
-			selector: 'self::li',
+			selector: xq`self::li`,
 			nodeName: 'li'
 		},
 		paragraph: {
@@ -520,21 +521,21 @@ export default function configureSxModule(sxModule) {
 
 	// p
 	//     A paragraph element (<p>) is a block of text containing a single main idea. Category: Body elements
-	configureAsBlock(sxModule, 'self::p', t('paragraph'));
+	configureAsBlock(sxModule, xq`self::p`, t('paragraph'));
 
 	// param
 	//     The parameter (<param>) element specifies a set of values that may be required by an <object> at
 	//     runtime. Any number of <param> elements may appear in the content of an object in any order, but
 	//     must be placed at the start of the content of the enclosing object. This element is comparable to
 	//     the XHMTL <param> element. Category: Body elements
-	configureAsRemoved(sxModule, 'self::param', t('param'));
+	configureAsRemoved(sxModule, xq`self::param`, t('param'));
 
 	// ph
 	//     The phrase (<ph>) element is used to organize content for reuse or conditional processing (for
 	//     example, when part of a paragraph applies to a particular audience). It can be used by
 	//     specializations of DITA to create semantic markup for content at the phrase level, which then allows
 	//     (but does not require) specific processing or formatting. Category: Body elements
-	configureAsInlineFrame(sxModule, 'self::ph', t('phrase'), {
+	configureAsInlineFrame(sxModule, xq`self::ph`, t('phrase'), {
 		backgroundColor: 'blue'
 	});
 
@@ -543,7 +544,7 @@ export default function configureSxModule(sxModule) {
 	//     the content of the element, and also presents the content in a monospaced type font (depending on
 	//     your output formatting processor). Do not use <pre> when a more semantically specific element is
 	//     appropriate, such as <codeblock>. Category: Body elements
-	configureAsGroupWithBlock(sxModule, 'self::pre', t('preformatted text'), {
+	configureAsGroupWithBlock(sxModule, xq`self::pre`, t('preformatted text'), {
 		expression: 'compact',
 		withNewlineBreakToken: true,
 		allowAutocapitalization: false
@@ -553,7 +554,7 @@ export default function configureSxModule(sxModule) {
 	//     A quotation element (<q>) indicates content quoted from another source. This element is used for
 	//     short quotes which are displayed inline. Use the long quote element (<lq>) for quotations that
 	//     should be set off from the surrounding text. Category: Body elements
-	configureAsInlineFrame(sxModule, 'self::q', t('quote'), {
+	configureAsInlineFrame(sxModule, xq`self::q`, t('quote'), {
 		endDelimiter: '’',
 		slant: 'italic',
 		startDelimiter: '‘'
@@ -564,7 +565,7 @@ export default function configureSxModule(sxModule) {
 	//     appropriately tagged without manual intervention. As the element name implies, the intent for
 	//     authors is to clean up the contained material and eventually get rid of the <required-cleanup>
 	//     element. Authors should not insert this element into documents. Category: Specialization elements
-	configureAsRemoved(sxModule, 'self::required-cleanup', t('required-cleanup'));
+	configureAsRemoved(sxModule, xq`self::required-cleanup`, t('required-cleanup'));
 
 	// simpletable
 	//     The <simpletable> element is used for tables that are regular in structure and do not need a
@@ -582,9 +583,9 @@ export default function configureSxModule(sxModule) {
 		showSelectionWidget: true
 	});
 
-	configureProperties(sxModule, 'self::simpletable', {
+	configureProperties(sxModule, xq`self::simpletable`, {
 		markupLabel: t('simple table'),
-		tabNavigationItemSelector: 'self::stentry',
+		tabNavigationItemSelector: xq`self::stentry`,
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
@@ -596,8 +597,8 @@ export default function configureSxModule(sxModule) {
 	//     text content, adequate for describing package contents, for example. When a DITA topic is formatted
 	//     for output, the items of a simple list are placed each on its own line, with no other prefix such as
 	//     a number (as in an ordered list) or bullet (as in an unordered list). Category: Body elements
-	configureMarkupLabel(sxModule, 'self::sl', t('simple list'));
-	configureProperties(sxModule, 'self::sli', {
+	configureMarkupLabel(sxModule, xq`self::sl`, t('simple list'));
+	configureProperties(sxModule, xq`self::sli`, {
 		contextualOperations: [
 			{ name: ':contextual-insert-sli--above' },
 			{ name: ':contextual-insert-sli--below' }
@@ -607,11 +608,11 @@ export default function configureSxModule(sxModule) {
 
 	configureAsListElements(sxModule, {
 		list: {
-			selector: 'self::sl',
+			selector: xq`self::sl`,
 			style: configureAsListElements.EMPTY_LIST_STYLE
 		},
 		item: {
-			selector: 'self::sli',
+			selector: xq`self::sli`,
 			nodeName: 'sli'
 		}
 	});
@@ -621,26 +622,26 @@ export default function configureSxModule(sxModule) {
 	//     that has a variable value. The element is primarily intended for use in specializations to represent
 	//     specific states (like logic circuit states, chemical reaction states, airplane instrumentation
 	//     states, and so forth). Category: Specialization elements
-	configureAsRemoved(sxModule, 'self::state', t('state'));
+	configureAsRemoved(sxModule, xq`self::state`, t('state'));
 
 	// stentry
 	//     The simpletable entry (<stentry>) element represents a single table cell, like <entry> in <table>.
 	//     You can place any number of stentry cells in either an <sthead> element (for headings) or <strow>
 	//     element (for rows of data). Category: Table elements
-	configureProperties(sxModule, 'self::stentry', {
+	configureProperties(sxModule, xq`self::stentry`, {
 		markupLabel: t('cell')
 	});
 
 	// sthead
 	//     The simpletable header (<sthead>) element contains the table's header row. The header row is
 	//     optional in a simple table. Category: Table elements
-	configureProperties(sxModule, 'self::sthead', {
+	configureProperties(sxModule, xq`self::sthead`, {
 		markupLabel: t('row')
 	});
 
 	// strow
 	//     The <simpletable> row (<strow>) element specifies a row in a simple table. Category: Table elements
-	configureProperties(sxModule, 'self::strow', {
+	configureProperties(sxModule, xq`self::strow`, {
 		markupLabel: t('row')
 	});
 
@@ -648,7 +649,7 @@ export default function configureSxModule(sxModule) {
 	//     The <term> element identifies words that may have or require extended definitions or explanations.
 	//     In future development of DITA, for example, terms might provide associative linking to matching
 	//     glossary entries. Category: Specialization elements
-	configureAsInlineFrame(sxModule, 'self::term', t('term'), {
+	configureAsInlineFrame(sxModule, xq`self::term`, t('term'), {
 		backgroundColor: 'blue'
 	});
 
@@ -658,14 +659,14 @@ export default function configureSxModule(sxModule) {
 	//     specializations). Unlike ph, text cannot contain images. Unlike keyword, text does not imply
 	//     keyword-like semantics. The text element contains only text data, or nested text elements. All
 	//     universal attributes are available on text.
-	configureAsRemoved(sxModule, 'self::text', t('text'));
+	configureAsRemoved(sxModule, xq`self::text`, t('text'));
 
 	// title
 	//     The <title> element contains a heading or label for the main parts of a topic, including the topic
 	//     as a whole, its sections and examples, and its labelled content, such as figures and tables.
 	//     Beginning with DITA 1.1, the element may also be used to provide a title for a map. Category: Topic
 	//     elements
-	configureAsTitleFrame(sxModule, 'self::title', t('title'), {
+	configureAsTitleFrame(sxModule, xq`self::title`, t('title'), {
 		emptyElementPlaceholderText: t('type the title')
 	});
 
@@ -673,25 +674,25 @@ export default function configureSxModule(sxModule) {
 	//     The trademark (<tm>) element in DITA is used to markup and identify a term or phrase that is
 	//     trademarked. Trademarks include registered trademarks, service marks, slogans and logos. Category:
 	//     Miscellaneous elements
-	configureAsInlineFrame(sxModule, 'self::tm', t('trademark'), {
+	configureAsInlineFrame(sxModule, xq`self::tm`, t('trademark'), {
 		endDelimiter: '™'
 	});
-	configureProperties(sxModule, 'self::tm[@tmtype="reg"]', {
+	configureProperties(sxModule, xq`self::tm[@tmtype="reg"]`, {
 		markupLabel: t('registered trademark'),
 		endDelimiter: '®'
 	});
 
-	configureProperties(sxModule, 'self::tm[@tmtype="service"]', {
+	configureProperties(sxModule, xq`self::tm[@tmtype="service"]`, {
 		markupLabel: t('servicemark'),
 		endDelimiter: '℠'
 	});
 
-	configureProperties(sxModule, 'self::tm[@tmtype="reg"]', {
+	configureProperties(sxModule, xq`self::tm[@tmtype="reg"]`, {
 		markupLabel: t('registered trademark'),
 		endDelimiter: '®'
 	});
 
-	configureProperties(sxModule, 'self::tm[@tmtype="service"]', {
+	configureProperties(sxModule, xq`self::tm[@tmtype="service"]`, {
 		markupLabel: t('service mark'),
 		endDelimiter: '℠'
 	});
@@ -702,17 +703,17 @@ export default function configureSxModule(sxModule) {
 	//     In an unordered list (<ul>), the order of the list items is not significant. List items are
 	//     typically styled on output with a "bullet" character, depending on nesting level. Category: Body
 	//     elements
-	configureMarkupLabel(sxModule, 'self::ul', t('bulleted list'));
-	configureContextualOperations(sxModule, 'self::ul', [{ name: ':ul-convert-to-ol' }]);
+	configureMarkupLabel(sxModule, xq`self::ul`, t('bulleted list'));
+	configureContextualOperations(sxModule, xq`self::ul`, [{ name: ':ul-convert-to-ol' }]);
 
 	configureAsListElements(sxModule, {
 		list: {
-			selector: 'self::ul',
+			selector: xq`self::ul`,
 			style: configureAsListElements.BULLETED_LIST_STYLE,
 			nodeName: 'ul'
 		},
 		item: {
-			selector: 'self::li',
+			selector: xq`self::li`,
 			nodeName: 'li'
 		},
 		paragraph: {
@@ -724,30 +725,30 @@ export default function configureSxModule(sxModule) {
 	//     The <unknown> element is an open extension that allows information architects to incorporate xml
 	//     fragments that do not necessarily fit into an existing DITA use case. The base processing for
 	//     <unknown> is to suppress unless otherwise instructed. Category: Specialization elements
-	configureAsRemoved(sxModule, 'self::unknown', t('unknown'));
+	configureAsRemoved(sxModule, xq`self::unknown`, t('unknown'));
 
 	// xref
 	//     Use the cross-reference (<xref>) element to link to a different location within the current topic,
 	//     or a different topic within the same help system, or to external sources, such as Web pages, or to a
 	//     location in another topic. The href attribute on the <xref> element provides the location of the
 	//     target. Category: Body elements
-	configureAsInlineLink(sxModule, 'self::xref', t('link'), {
+	configureAsInlineLink(sxModule, xq`self::xref`, t('link'), {
 		emptyElementPlaceholderText: t('type the link text'),
-		referenceQuery: '@href',
+		referenceQuery: xq`@href`,
 		popoverComponentName: 'DitaCrossReferencePopover',
 		popoverData: {
 			editOperationName: ':contextual-edit-xref[@format=dita]',
 			targetIsPermanentId: false,
-			targetQuery: '@href'
+			targetQuery: xq`@href`
 		}
 	});
 
-	configureProperties(sxModule, 'self::xref[@format="html"]', {
+	configureProperties(sxModule, xq`self::xref[@format="html"]`, {
 		popoverComponentName: 'WebReferencePopover',
 		popoverData: {
 			editOperationName: ':contextual-edit-xref[@format=html]',
 			targetIsPermanentId: false,
-			targetQuery: '@href'
+			targetQuery: xq`@href`
 		}
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.js
@@ -487,7 +487,7 @@ export default function configureSxModule(sxModule) {
 
 	Object.keys(NOTE_VISUALIZATION_BY_TYPE).forEach(function(noteType) {
 		const noteVisualization = NOTE_VISUALIZATION_BY_TYPE[noteType];
-		configureProperties(sxModule, xq`self::note[@type="${noteType}"]`, {
+		configureProperties(sxModule, xq`self::note[@type=${noteType}]`, {
 			markupLabel: noteVisualization.label,
 			contextualOperations: getContextualOperationsForNoteType(noteType),
 			backgroundColor: noteVisualization.backgroundColor

--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureXrefToUsePermanentId.js
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureXrefToUsePermanentId.js
@@ -1,27 +1,28 @@
 import configureAsInlineLink from 'fontoxml-families/src/configureAsInlineLink.js';
 import configureProperties from 'fontoxml-families/src/configureProperties.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureXrefToUsePermanentId(sxModule) {
 	// To enable permanentId's in cross references (also known as the reference pipeline), reconfigure the attribute
 	// name that is expected to contain the permanentId, and set popoverData.targetIsPermanent to TRUE.
 
-	configureAsInlineLink(sxModule, 'self::xref', undefined, {
-		referenceQuery: '@href',
+	configureAsInlineLink(sxModule, xq`self::xref`, undefined, {
+		referenceQuery: xq`@href`,
 		isPermanentId: true,
 		priority: 2,
 		popoverData: {
 			editOperationName: ':contextual-edit-xref[@format=dita]',
 			targetIsPermanentId: true,
-			targetQuery: '@href'
+			targetQuery: xq`@href`
 		}
 	});
 
-	configureProperties(sxModule, 'self::xref[@format="html"]', {
+	configureProperties(sxModule, xq`self::xref[@format="html"]`, {
 		priority: 2,
 		popoverData: {
 			editOperationName: ':contextual-edit-xref[@format=html]',
 			targetIsPermanentId: true,
-			targetQuery: '@href'
+			targetQuery: xq`@href`
 		}
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-concept-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-concept-mod/src/configureSxModule.js
@@ -7,6 +7,7 @@ import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMe
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// conbody
@@ -14,7 +15,7 @@ export default function configureSxModule(sxModule) {
 	//     general <topic>, <conbody> allows paragraphs, lists, and other elements as well as sections and
 	//     examples. But <conbody> has a constraint that a section or an example can be followed only by other
 	//     sections or examples. Category: Concept elements
-	configureAsStructure(sxModule, 'self::conbody', t('body'), {
+	configureAsStructure(sxModule, xq`self::conbody`, t('body'), {
 		defaultTextContainer: 'p',
 		isRemovableIfEmpty: false
 	});
@@ -22,14 +23,14 @@ export default function configureSxModule(sxModule) {
 	// section in conbody/conbodydiv
 	configureContextualOperations(
 		sxModule,
-		'self::section[parent::conbodydiv or (parent::conbody and preceding-sibling::*[1][self::section or self::example or self::conbodydiv])]',
+		xq`self::section[parent::conbodydiv or (parent::conbody and preceding-sibling::*[1][self::section or self::example or self::conbodydiv])]`,
 		[{ name: ':section-insert-title' }, { name: ':contextual-delete-section' }]
 	);
 
 	// example in conbody/conbodydiv
 	configureContextualOperations(
 		sxModule,
-		'self::example[parent::conbodydiv or (parent::conbody and preceding-sibling::*[1][self::section or self::example or self::conbodydiv])]',
+		xq`self::example[parent::conbodydiv or (parent::conbody and preceding-sibling::*[1][self::section or self::example or self::conbodydiv])]`,
 		[{ name: ':example-insert-title' }, { name: ':contextual-delete-example' }]
 	);
 
@@ -38,7 +39,7 @@ export default function configureSxModule(sxModule) {
 	//     container for content that may be grouped within a concept. There are no additional semantics
 	//     attached to the conbodydiv element; it is purely a grouping element provided to help organize
 	//     content.
-	configureAsFrame(sxModule, 'self::conbodydiv', t('body division'), {
+	configureAsFrame(sxModule, xq`self::conbodydiv`, t('body division'), {
 		contextualOperations: [{ name: ':contextual-unwrap-conbodydiv' }],
 		defaultTextContainer: 'section',
 		emptyElementPlaceholderText: t('type the content'),
@@ -53,14 +54,14 @@ export default function configureSxModule(sxModule) {
 	//     a product or interface. Often, a concept is an extended definition of a major abstraction such as a
 	//     process or function. It might also have an example or a graphic, but generally the structure of a
 	//     concept is fairly simple. Category: Concept elements
-	configureAsSheetFrame(sxModule, 'self::concept', t('concept'), {
+	configureAsSheetFrame(sxModule, xq`self::concept`, t('concept'), {
 		defaultTextContainer: 'conbody',
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -69,17 +70,17 @@ export default function configureSxModule(sxModule) {
 	// concept nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::concept[parent::*[fonto:dita-class(., "topic/topic")]]',
+		xq`self::concept[parent::*[fonto:dita-class(., "topic/topic")]]`,
 		undefined,
 		{
 			defaultTextContainer: 'conbody',
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in concept
-	configureAsTitleFrame(sxModule, 'self::title[parent::concept]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::concept]`, undefined, {
 		fontVariation: 'document-title'
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-equation-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-equation-domain/src/configureSxModule.js
@@ -5,6 +5,7 @@ import configureAsTitleFrame from 'fontoxml-families/src/configureAsTitleFrame.j
 import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMenuButtonWidget.js';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// equation-block
@@ -13,7 +14,7 @@ export default function configureSxModule(sxModule) {
 	//     including embedded MathML using the <mathml> specialization of <foreign>, a reference to an image,
 	//     inline TeX markup, or any other way that an equation might be defined. The equation may include
 	//     alternative forms, such as both a MathML version and an image.
-	configureAsFrameWithBlock(sxModule, 'self::equation-block', t('equation'), {
+	configureAsFrameWithBlock(sxModule, xq`self::equation-block`, t('equation'), {
 		contextualOperations: [{ name: 'mathml-edit' }],
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -32,7 +33,7 @@ export default function configureSxModule(sxModule) {
 	//     specialization of <foreign>, a reference to an image, inline TeX markup, or any other way that an
 	//     equation might be defined. The equation may include alternative forms, such as both a MathML version
 	//     and an image.
-	configureAsFrame(sxModule, 'self::equation-figure', t('equation figure'), {
+	configureAsFrame(sxModule, xq`self::equation-figure`, t('equation figure'), {
 		contextualOperations: [
 			{ name: ':equation-figure-insert-title' },
 			{ name: ':equation-figure-insert-desc' },
@@ -43,13 +44,13 @@ export default function configureSxModule(sxModule) {
 			},
 			{ name: ':contextual-delete-equation-figure' }
 		],
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// title in equation-figure
-	configureAsTitleFrame(sxModule, 'self::title[parent::equation-figure]', t('title'), {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::equation-figure]`, t('title'), {
 		fontVariation: 'figure-title'
 	});
 
@@ -59,7 +60,7 @@ export default function configureSxModule(sxModule) {
 	//     of ways, including embedded MathML using the <mathml> specialization of <foreign>, a reference to an
 	//     image, inline TeX markup, or any other way that an equation might be defined. The equation may
 	//     include alternative forms, such as both a MathML version and an image.
-	configureAsInlineFrame(sxModule, 'self::equation-inline', t('inline equation'), {
+	configureAsInlineFrame(sxModule, xq`self::equation-inline`, t('inline equation'), {
 		contextualOperations: [{ name: 'mathml-edit' }]
 	});
 
@@ -68,5 +69,5 @@ export default function configureSxModule(sxModule) {
 	//     the <equation-number> element has empty or whitespace-only content, then the number should be
 	//     generated. If the <equation-number> element has content other than whitespace, the content should be
 	//     used as the number.
-	configureAsInlineFrame(sxModule, 'self::equation-number', t('equation number'));
+	configureAsInlineFrame(sxModule, xq`self::equation-number`, t('equation number'));
 }

--- a/packages/dita-example-sx-modules-xsd-glossentry-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-glossentry-mod/src/configureSxModule.js
@@ -8,12 +8,13 @@ import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMe
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// glossAbbreviation
 	//     The <glossAbbreviation> element provides an abbreviated form of the term contained in a <glossterm>
 	//     element.
-	configureAsFrameWithBlock(sxModule, 'self::glossAbbreviation', t('abbreviation'), {
+	configureAsFrameWithBlock(sxModule, xq`self::glossAbbreviation`, t('abbreviation'), {
 		emptyElementPlaceholderText: t('type the abbreviation for this term'),
 		isRemovableIfEmpty: false,
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -22,7 +23,7 @@ export default function configureSxModule(sxModule) {
 	// glossAcronym
 	//     The <glossAcronym> element defines an acronym as an alternate form for the term defined in the
 	//     <glossterm> element.
-	configureAsFrameWithBlock(sxModule, 'self::glossAcronym', t('acronym'), {
+	configureAsFrameWithBlock(sxModule, xq`self::glossAcronym`, t('acronym'), {
 		emptyElementPlaceholderText: t('type the acronym for this term'),
 		isRemovableIfEmpty: false,
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -33,7 +34,7 @@ export default function configureSxModule(sxModule) {
 	//     same meaning as the term in the <glossterm> element; the variant is simply another way to refer to
 	//     the same term. There may be many ways to refer to a term; each variant is placed in its own
 	//     <glossAlt> element.
-	configureAsFrame(sxModule, 'self::glossAlt', t('variation'), {
+	configureAsFrame(sxModule, xq`self::glossAlt`, t('variation'), {
 		contextualOperations: [
 			{ name: ':glossAlt-convert-to-glossAbbreviation' },
 			{ name: ':glossAlt-convert-to-glossAcronym' },
@@ -49,19 +50,19 @@ export default function configureSxModule(sxModule) {
 	// glossAlternateFor
 	//     The <glossAlternateFor> element indicates when a variant term has a relationship to another variant
 	//     term as well as to the preferred term.
-	configureAsRemoved(sxModule, 'self::glossAlternateFor', t('alternate for'));
+	configureAsRemoved(sxModule, xq`self::glossAlternateFor`, t('alternate for'));
 
 	// glossBody
 	//     The <glossbody> element is used to provide details about a glossary term (such as part of speech or
 	//     additional forms of the term).
-	configureAsStructure(sxModule, 'self::glossBody', t('body'), {
+	configureAsStructure(sxModule, xq`self::glossBody`, t('body'), {
 		isAutoremovableIfEmpty: true
 	});
 
 	// glossdef
 	//     The <glossdef> element specifies the definition of one sense of a term. If a term has multiple
 	//     senses, create a separate <glossentry> topic to define each sense. Category: Glossentry elements
-	configureAsFrameWithBlock(sxModule, 'self::glossdef', t('definition'), {
+	configureAsFrameWithBlock(sxModule, xq`self::glossdef`, t('definition'), {
 		emptyElementPlaceholderText: t('define the term'),
 		defaultTextContainer: 'p',
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -75,13 +76,13 @@ export default function configureSxModule(sxModule) {
 	//     translation of the terms. One possible online processing is to associate a hotspot for mentions of
 	//     terms in <term> elements and display the definition on hover or click. Glossary entries for
 	//     different term senses can be reused independently of one another. Category: Glossentry elements
-	configureAsSheetFrame(sxModule, 'self::glossentry', t('entry'), {
+	configureAsSheetFrame(sxModule, xq`self::glossentry`, t('entry'), {
 		titleQuery:
-			'./glossterm//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./glossterm//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -90,7 +91,7 @@ export default function configureSxModule(sxModule) {
 	// glossentry nested in topic (including glossgroup)
 	configureAsFrame(
 		sxModule,
-		'self::glossentry[parent::*[fonto:dita-class(., "topic/topic")]]',
+		xq`self::glossentry[parent::*[fonto:dita-class(., "topic/topic")]]`,
 		undefined,
 		{
 			contextualOperations: [
@@ -100,7 +101,7 @@ export default function configureSxModule(sxModule) {
 				{ name: ':contextual-insert-glossentry--below' },
 				{ name: ':contextual-delete-glossentry' }
 			],
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()],
 			blockOutsideAfter: [createElementMenuButtonWidget()]
 		}
@@ -111,24 +112,24 @@ export default function configureSxModule(sxModule) {
 	//     same part of speech as the preferred term because all terms in the glossentry topic designate the
 	//     same subject. If the part of speech isn't specified, the default is a noun for the standard
 	//     enumeration.
-	configureAsRemoved(sxModule, 'self::glossPartOfSpeech', t('part of speech'));
+	configureAsRemoved(sxModule, xq`self::glossPartOfSpeech`, t('part of speech'));
 
 	// glossProperty
 	//     The <glossProperty> element is an extension point which allows additional details about the
 	//     preferred term or its subject.
-	configureAsRemoved(sxModule, 'self::glossProperty', t('property'));
+	configureAsRemoved(sxModule, xq`self::glossProperty`, t('property'));
 
 	// glossScopeNote
 	//     A clarification of the subject designated by the <glossterm> such as examples of included or
 	//     excluded companies or products. For instance, a scope note for "Linux" might explain that the term
 	//     doesn't apply to UNIX products and give some examples of Linux products that are included as well as
 	//     UNIX products that are excluded.
-	configureAsRemoved(sxModule, 'self::glossScopeNote', t('scope note'));
+	configureAsRemoved(sxModule, xq`self::glossScopeNote`, t('scope note'));
 
 	// glossShortForm
 	//     The <glossShortForm> element provides a shorter alternative to the primary term specified in the
 	//     <glossterm> element.
-	configureAsFrameWithBlock(sxModule, 'self::glossShortForm', t('short form'), {
+	configureAsFrameWithBlock(sxModule, xq`self::glossShortForm`, t('short form'), {
 		emptyElementPlaceholderText: t('type the short form for this term'),
 		isRemovableIfEmpty: false,
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -137,21 +138,21 @@ export default function configureSxModule(sxModule) {
 	// glossStatus
 	//     Identifies the usage status of a preferred or alternate term. If the status isn't specified, the
 	//     <glossterm> provides a preferred term and an alternate term provides an allowed term.
-	configureAsRemoved(sxModule, 'self::glossStatus', t('status'));
+	configureAsRemoved(sxModule, xq`self::glossStatus`, t('status'));
 
 	// glossSurfaceForm
 	//     The <glossSurfaceForm> element specifies an unambiguous presentation of the <glossterm> that may
 	//     combine multiple forms. The surface form is suitable to introduce the term in new contexts.
-	configureAsRemoved(sxModule, 'self::glossSurfaceForm', t('surface form'));
+	configureAsRemoved(sxModule, xq`self::glossSurfaceForm`, t('surface form'));
 
 	// glossSymbol
 	//     The <glossSymbol> element identifies a standard image associated with the subject of the
 	//     <glossterm>.
-	configureAsRemoved(sxModule, 'self::glossSymbol', t('symbol'));
+	configureAsRemoved(sxModule, xq`self::glossSymbol`, t('symbol'));
 
 	// glossSynonym
 	//     Provides a term that is a synonym of the primary value in the <glossterm> element.
-	configureAsFrameWithBlock(sxModule, 'self::glossSynonym', t('synonym'), {
+	configureAsFrameWithBlock(sxModule, xq`self::glossSynonym`, t('synonym'), {
 		emptyElementPlaceholderText: t('type the synonym for this term'),
 		isRemovableIfEmpty: false,
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -161,20 +162,20 @@ export default function configureSxModule(sxModule) {
 	//     The <glossterm> element specifies the preferred term associated with a definition of a sense. If the
 	//     same term has multiple senses, create a separate <glossentry> topic for each sense. Category:
 	//     Glossentry elements
-	configureAsTitleFrame(sxModule, 'self::glossterm', t('term'), {
+	configureAsTitleFrame(sxModule, xq`self::glossterm`, t('term'), {
 		emptyElementPlaceholderText: t('type the term')
 	});
 
 	// glossUsage
 	//     The <glossUsage> element provides information about the correct use of a term, such as where or how
 	//     it can be used.
-	configureAsFrame(sxModule, 'self::glossUsage', t('usage'), {
+	configureAsFrame(sxModule, xq`self::glossUsage`, t('usage'), {
 		emptyElementPlaceholderText: t('explain how this term may be used'),
 		defaultTextContainer: 'p',
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
-	configureAsFrame(sxModule, 'self::glossUsage[parent::glossAlt]', t('usage'), {
+	configureAsFrame(sxModule, xq`self::glossUsage[parent::glossAlt]`, t('usage'), {
 		emptyElementPlaceholderText: t('explain how this variation may be used'),
 		defaultTextContainer: 'p',
 		blockHeaderLeft: [createMarkupLabelWidget()]

--- a/packages/dita-example-sx-modules-xsd-glossgroup-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-glossgroup-mod/src/configureSxModule.js
@@ -4,17 +4,18 @@ import configureAsTitleFrame from 'fontoxml-families/src/configureAsTitleFrame.j
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// glossgroup
 	//     The <glossgroup> element may be used to contain multiple <glossentry> topics within a single
 	//     collection.
-	configureAsSheetFrame(sxModule, 'self::glossgroup', t('glossary'), {
+	configureAsSheetFrame(sxModule, xq`self::glossgroup`, t('glossary'), {
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -23,7 +24,7 @@ export default function configureSxModule(sxModule) {
 	// glossgroup nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::glossgroup[parent::*[fonto:dita-class(., "topic/topic")]]',
+		xq`self::glossgroup[parent::*[fonto:dita-class(., "topic/topic")]]`,
 		undefined,
 		{
 			blockFooter: []
@@ -31,7 +32,7 @@ export default function configureSxModule(sxModule) {
 	);
 
 	// title in glossary
-	configureAsTitleFrame(sxModule, 'self::title[parent::glossgroup]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::glossgroup]`, undefined, {
 		fontVariation: 'document-title'
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureHazardsymbolWithoutPermanentId.js
+++ b/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureHazardsymbolWithoutPermanentId.js
@@ -1,4 +1,5 @@
 import configureAsImageInFrame from 'fontoxml-families/src/configureAsImageInFrame.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 // This file removes the permanentId which is the other way around then for cross reference,
 // for compatability reasons.
@@ -6,9 +7,9 @@ export default function configureHazardSymbolWithoutPermanentId(sxModule) {
 	// To disable permanentId's in hazard symbols (also known as the reference pipeline), set
 	// isPermanentId to false.
 
-	configureAsImageInFrame(sxModule, 'self::hazardsymbol', undefined, {
+	configureAsImageInFrame(sxModule, xq`self::hazardsymbol`, undefined, {
 		priority: 2,
-		referenceQuery: '@href',
+		referenceQuery: xq`@href`,
 		isPermanentId: false
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureSxModule.js
@@ -114,7 +114,7 @@ export default function configureSxModule(sxModule) {
 
 	Object.keys(HAZARD_VISUALIZATION_BY_TYPE).forEach(function(hazardType) {
 		var hazardVisualization = HAZARD_VISUALIZATION_BY_TYPE[hazardType];
-		configureProperties(sxModule, xq`self::hazardstatement[@type="${hazardType}"]`, {
+		configureProperties(sxModule, xq`self::hazardstatement[@type=${hazardType}]`, {
 			markupLabel: hazardVisualization.label,
 			contextualOperations: getContextualOperationsForHazardType(hazardType),
 			backgroundColor: hazardVisualization.backgroundColor

--- a/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureSxModule.js
@@ -6,12 +6,13 @@ import configureProperties from 'fontoxml-families/src/configureProperties.js';
 import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMenuButtonWidget.js';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// consequence
 	//     The <consequence> element is the container for the second text entry of a safety label. It contains
 	//     the description of the consequences of not avoiding the hazard, such as "Keep guard in place".
-	configureAsFrameWithBlock(sxModule, 'self::consequence', t('consequence'), {
+	configureAsFrameWithBlock(sxModule, xq`self::consequence`, t('consequence'), {
 		emptyElementPlaceholderText: t('type the consequence'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -103,7 +104,7 @@ export default function configureSxModule(sxModule) {
 		return contextualOperations;
 	}
 
-	configureAsFrame(sxModule, 'self::hazardstatement', t('hazard statement'), {
+	configureAsFrame(sxModule, xq`self::hazardstatement`, t('hazard statement'), {
 		contextualOperations: getContextualOperationsForHazardType('standard-hazard'),
 		defaultTextContainer: 'messagepanel',
 		isIgnoredForNavigation: false,
@@ -113,7 +114,7 @@ export default function configureSxModule(sxModule) {
 
 	Object.keys(HAZARD_VISUALIZATION_BY_TYPE).forEach(function(hazardType) {
 		var hazardVisualization = HAZARD_VISUALIZATION_BY_TYPE[hazardType];
-		configureProperties(sxModule, 'self::hazardstatement[@type="' + hazardType + '"]', {
+		configureProperties(sxModule, xq`self::hazardstatement[@type="${hazardType}"]`, {
 			markupLabel: hazardVisualization.label,
 			contextualOperations: getContextualOperationsForHazardType(hazardType),
 			backgroundColor: hazardVisualization.backgroundColor
@@ -124,19 +125,19 @@ export default function configureSxModule(sxModule) {
 	//     A graphic representation intended to convey a message without the use of words. It may represent a
 	//     hazard, a hazardous situation, a precaution to avoid a hazard, a result of not avoiding a hazard, or
 	//     any combination of these messages.
-	configureAsImageInFrame(sxModule, 'self::hazardsymbol', t('hazard symbol'), {
+	configureAsImageInFrame(sxModule, xq`self::hazardsymbol`, t('hazard symbol'), {
 		contextualOperations: [
 			{ name: ':contextual-edit-hazardsymbol' },
 			{ name: ':hazardsymbol-insert-alt' }
 		],
-		referenceQuery: '@href',
+		referenceQuery: xq`@href`,
 		isPermanentId: true
 	});
 
 	// howtoavoid
 	//     The <howtoavoid> element is the container for the third text entry of a safety label. It contains
 	//     the description of how to avoid the hazard, such as "Lock out power before servicing".
-	configureAsFrameWithBlock(sxModule, 'self::howtoavoid', t('how to avoid'), {
+	configureAsFrameWithBlock(sxModule, xq`self::howtoavoid`, t('how to avoid'), {
 		emptyElementPlaceholderText: t('type the description of how to avoid the hazard'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -145,7 +146,7 @@ export default function configureSxModule(sxModule) {
 	//     The <messagepanel> element describes the area of a safety sign or label that contains the word
 	//     message which identifies a hazard, indicates how to avoid the hazard, and advises of the probable
 	//     consequences of not avoiding the hazard.
-	configureAsFrame(sxModule, 'self::messagepanel', t('message panel'), {
+	configureAsFrame(sxModule, xq`self::messagepanel`, t('message panel'), {
 		contextualOperations: [
 			{ name: ':messagepanel-append-consequence', hideIn: ['context-menu'] },
 			{
@@ -168,7 +169,7 @@ export default function configureSxModule(sxModule) {
 	// typeofhazard
 	//     <typeofhazard> element is the container for the first text entry of a safety label. It contains the
 	//     description of the type of hazard, such as "Moving parts can crush and cut".
-	configureAsTitleFrame(sxModule, 'self::typeofhazard', t('type of hazard'), {
+	configureAsTitleFrame(sxModule, xq`self::typeofhazard`, t('type of hazard'), {
 		emptyElementPlaceholderText: t('type the type of hazard'),
 		fontVariation: 'figure-title'
 	});

--- a/packages/dita-example-sx-modules-xsd-highlight-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-highlight-domain/src/configureSxModule.js
@@ -1,5 +1,6 @@
 import configureAsInlineFormatting from 'fontoxml-families/src/configureAsInlineFormatting.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// b
@@ -7,26 +8,26 @@ export default function configureSxModule(sxModule) {
 	//     element only when there is not some other more proper element. For example, for specific items such
 	//     as GUI controls, use the <uicontrol> element. This element is part of the DITA highlighting domain.
 	//     Category: Typographic elements
-	configureAsInlineFormatting(sxModule, 'self::b', t('bold text'), {
+	configureAsInlineFormatting(sxModule, xq`self::b`, t('bold text'), {
 		weight: 'bold'
 	});
 
 	// i
 	//     The italic (<i>) element is used to apply italic highlighting to the content of the element.
 	//     Category: Typographic elements
-	configureAsInlineFormatting(sxModule, 'self::i', t('italic text'), {
+	configureAsInlineFormatting(sxModule, xq`self::i`, t('italic text'), {
 		slant: 'italic'
 	});
 
 	// line-through
 	//     Category: Typographic elements
-	configureAsInlineFormatting(sxModule, 'self::line-through', t('strike-through'), {
+	configureAsInlineFormatting(sxModule, xq`self::line-through`, t('strike-through'), {
 		lineThroughStyle: 'single'
 	});
 
 	// overline
 	//     Category: Typographic elements
-	configureAsInlineFormatting(sxModule, 'self::overline', t('overline'), {
+	configureAsInlineFormatting(sxModule, xq`self::overline`, t('overline'), {
 		overlineStyle: 'single'
 	});
 
@@ -35,7 +36,7 @@ export default function configureSxModule(sxModule) {
 	//     the surrounding text. Subscripted text is often a smaller font than the surrounding text. Formatting
 	//     may vary depending on your output process. This element is part of the DITA highlighting domain.
 	//     Category: Typographic elements
-	configureAsInlineFormatting(sxModule, 'self::sub', t('subscript text'), {
+	configureAsInlineFormatting(sxModule, xq`self::sub`, t('subscript text'), {
 		baseline: 'subscript'
 	});
 
@@ -44,21 +45,21 @@ export default function configureSxModule(sxModule) {
 	//     relationship to the surrounding text. Superscripts are usually a smaller font than the surrounding
 	//     text. Use this element only when there is not some other more proper tag. This element is part of
 	//     the DITA highlighting domain. Category: Typographic elements
-	configureAsInlineFormatting(sxModule, 'self::sup', t('superscript text'), {
+	configureAsInlineFormatting(sxModule, xq`self::sup`, t('superscript text'), {
 		baseline: 'superscript'
 	});
 
 	// tt
 	//     The teletype (<tt>) element is used to apply monospaced highlighting to the content of the element.
 	//     Category: Typographic elements
-	configureAsInlineFormatting(sxModule, 'self::tt', t('teletype'), {
+	configureAsInlineFormatting(sxModule, xq`self::tt`, t('teletype'), {
 		isMonospaced: 'true'
 	});
 
 	// u
 	//     The underline (<u>) element is used to apply underline highlighting to the content of the element.
 	//     Category: Typographic elements
-	configureAsInlineFormatting(sxModule, 'self::u', t('underlined text'), {
+	configureAsInlineFormatting(sxModule, xq`self::u`, t('underlined text'), {
 		underlineStyle: 'single'
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.js
@@ -4,13 +4,14 @@ import configureAsStructure from 'fontoxml-families/src/configureAsStructure.js'
 import configureAsTitleFrame from 'fontoxml-families/src/configureAsTitleFrame.js';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// anchorref
 	//     The contents of an <anchorref> element are rendered both in the original authored location and at
 	//     the location of the referenced <anchor> element. The referenced <anchor> element can be defined in
 	//     the current map or another map.
-	configureAsRemoved(sxModule, 'self::anchorref', t('anchorref'));
+	configureAsRemoved(sxModule, xq`self::anchorref`, t('anchorref'));
 
 	// keydef
 	//     The <keydef> element is a convenience element that is used to define keys without any of the other
@@ -18,33 +19,33 @@ export default function configureSxModule(sxModule) {
 	//     included in the table of contents, and no linking or other relationships are defined. The <keydef>
 	//     element is not the only way to define keys; its purpose is to simplify the process by defaulting
 	//     several attributes to achieve the described behaviors.
-	configureAsRemoved(sxModule, 'self::keydef', t('keydef'));
+	configureAsRemoved(sxModule, xq`self::keydef`, t('keydef'));
 
 	// mapref
 	//     The <mapref> element is a convenience element that has the same meaning as a <topicref> element that
 	//     explicitly sets the format attribute to "ditamap". The hierarchy of the referenced map is merged
 	//     into the container map at the position of the reference, and the relationship tables of the child
 	//     map are added to the parent map.
-	configureAsRemoved(sxModule, 'self::mapref', t('mapref'));
+	configureAsRemoved(sxModule, xq`self::mapref`, t('mapref'));
 
 	// topichead
 	//     The <topichead> element provides a title-only entry in a navigation map, as an alternative to the
 	//     fully-linked title provided by the <topicref> element. Category: Mapgroup elements
-	configureAsMapSheetFrame(sxModule, 'self::topichead', t('topic group'), {
+	configureAsMapSheetFrame(sxModule, xq`self::topichead`, t('topic group'), {
 		titleQuery:
-			'if (topicmeta/navtitle) then (topicmeta/navtitle//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()) else string(./@navtitle)',
+			xq`if (topicmeta/navtitle) then (topicmeta/navtitle//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()) else string(./@navtitle)`,
 		variation: 'compact-vertical',
-		visibleChildSelectorOrNodeSpec: 'self::topicmeta',
+		visibleChildSelectorOrNodeSpec: xq`self::topicmeta`,
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// topicmeta in topichead
-	configureAsStructure(sxModule, 'self::topicmeta[parent::topichead]', undefined);
+	configureAsStructure(sxModule, xq`self::topicmeta[parent::topichead]`, undefined);
 
 	// navtitle in topicmeta in topichead
 	configureAsTitleFrame(
 		sxModule,
-		'self::navtitle and parent::topicmeta[parent::topichead]',
+		xq`self::navtitle and parent::topicmeta[parent::topichead]`,
 		undefined,
 		{
 			fontVariation: 'document-title'
@@ -56,9 +57,9 @@ export default function configureSxModule(sxModule) {
 	//     hierarchy, as opposed to nested < topicref> elements within a <topicref>, which does imply a
 	//     structural hierarchy. It is typically used outside a hierarchy to identify groups for linking
 	//     without affecting the resulting toc/navigation output. Category: Mapgroup elements
-	configureAsMapSheetFrame(sxModule, 'self::topicgroup', t('untitled topic group'), {
+	configureAsMapSheetFrame(sxModule, xq`self::topicgroup`, t('untitled topic group'), {
 		variation: 'compact-vertical',
-		visibleChildSelectorOrNodeSpec: 'self::topicmeta',
+		visibleChildSelectorOrNodeSpec: xq`self::topicmeta`,
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
@@ -67,10 +68,10 @@ export default function configureSxModule(sxModule) {
 	//     other <topicset> elements. The <topicset> element can be especially useful for task composition in
 	//     which larger tasks that are composed indefinitely of smaller tasks. The id attribute on a <topicset>
 	//     is required, which ensures that the complete unit is available for reuse in other contexts.
-	configureAsRemoved(sxModule, 'self::topicset', t('topicset'));
+	configureAsRemoved(sxModule, xq`self::topicset`, t('topicset'));
 
 	// topicsetref
 	//     The <topicsetref> element references a <topicset> element. The referenced <topicset> element can be
 	//     defined in the current map or in another map.
-	configureAsRemoved(sxModule, 'self::topicsetref', t('topicsetref'));
+	configureAsRemoved(sxModule, xq`self::topicsetref`, t('topicsetref'));
 }

--- a/packages/dita-example-sx-modules-xsd-map-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-map-mod/src/configureSxModule.js
@@ -5,54 +5,55 @@ import configureAsTitleFrame from 'fontoxml-families/src/configureAsTitleFrame.j
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// anchor
-	configureAsRemoved(sxModule, 'self::anchor', t('anchor'));
+	configureAsRemoved(sxModule, xq`self::anchor`, t('anchor'));
 
 	// linktext
-	configureAsRemoved(sxModule, 'self::linktext', t('link text'));
+	configureAsRemoved(sxModule, xq`self::linktext`, t('link text'));
 
 	// map
-	configureAsMapSheetFrame(sxModule, 'self::map', t('map'), {
+	configureAsMapSheetFrame(sxModule, xq`self::map`, t('map'), {
 		defaultTextContainer: 'title',
 		titleQuery:
-			'title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		variation: 'compact-vertical',
-		visibleChildSelectorOrNodeSpec: 'self::title',
+		visibleChildSelectorOrNodeSpec: xq`self::title`,
 		blockFooter: [
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// title in map
-	configureAsTitleFrame(sxModule, 'self::title[parent::map]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::map]`, undefined, {
 		fontVariation: 'collection-title'
 	});
 
 	// navref
-	configureAsRemoved(sxModule, 'self::navref', t('navref'));
+	configureAsRemoved(sxModule, xq`self::navref`, t('navref'));
 
 	// relcell
-	configureAsRemoved(sxModule, 'self::relcell', t('relcell'));
+	configureAsRemoved(sxModule, xq`self::relcell`, t('relcell'));
 
 	// relcolspec
-	configureAsRemoved(sxModule, 'self::relcolspec', t('relcolspec'));
+	configureAsRemoved(sxModule, xq`self::relcolspec`, t('relcolspec'));
 
 	// relheader
-	configureAsRemoved(sxModule, 'self::relheader', t('relheader'));
+	configureAsRemoved(sxModule, xq`self::relheader`, t('relheader'));
 
 	// relrow
-	configureAsRemoved(sxModule, 'self::relrow', t('relrow'));
+	configureAsRemoved(sxModule, xq`self::relrow`, t('relrow'));
 
 	// reltable
-	configureAsRemoved(sxModule, 'self::reltable', t('reltable'));
+	configureAsRemoved(sxModule, xq`self::reltable`, t('reltable'));
 
 	// searchtitle
-	configureAsRemoved(sxModule, 'self::searchtitle', t('searchtitle'));
+	configureAsRemoved(sxModule, xq`self::searchtitle`, t('searchtitle'));
 
 	// shortdesc
 	//     The short description (<shortdesc>) element occurs between the topic title and the topic body, as
@@ -60,16 +61,16 @@ export default function configureSxModule(sxModule) {
 	//     short description, which represents the purpose or theme of the topic, is also intended to be used
 	//     as a link preview and for searching. When used within a DITA map, the short description of the
 	//     <topicref> can be used to override the short description in the topic. Category: Topic elements
-	configureAsRemoved(sxModule, 'self::shortdesc', t('introduction'));
+	configureAsRemoved(sxModule, xq`self::shortdesc`, t('introduction'));
 
 	// topichead
 	//     The <topichead> element provides a title-only entry in a navigation map, as an alternative to the
 	//     fully-linked title provided by the <topicref> element. Category: Mapgroup elements
-	configureAsMapSheetFrame(sxModule, 'self::topichead', t('topic group'), {
+	configureAsMapSheetFrame(sxModule, xq`self::topichead`, t('topic group'), {
 		titleQuery:
-			'if (topicmeta/navtitle) then (topicmeta/navtitle//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()) else string(./@navtitle)',
+			xq`if (topicmeta/navtitle) then (topicmeta/navtitle//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()) else string(./@navtitle)`,
 		variation: 'compact-vertical',
-		visibleChildSelectorOrNodeSpec: 'self::topicmeta',
+		visibleChildSelectorOrNodeSpec: xq`self::topicmeta`,
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
@@ -78,21 +79,21 @@ export default function configureSxModule(sxModule) {
 	//     hierarchy, as opposed to nested < topicref> elements within a <topicref>, which does imply a
 	//     structural hierarchy. It is typically used outside a hierarchy to identify groups for linking
 	//     without affecting the resulting toc/navigation output. Category: Mapgroup elements
-	configureAsMapSheetFrame(sxModule, 'self::topicgroup', t('untitled topic group'), {
+	configureAsMapSheetFrame(sxModule, xq`self::topicgroup`, t('untitled topic group'), {
 		variation: 'compact-vertical',
-		visibleChildSelectorOrNodeSpec: 'self::topicmeta',
+		visibleChildSelectorOrNodeSpec: xq`self::topicmeta`,
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
 
 	// topicmeta
-	configureAsRemoved(sxModule, 'self::topicmeta', t('topic metadata'));
+	configureAsRemoved(sxModule, xq`self::topicmeta`, t('topic metadata'));
 
-	configureAsStructure(sxModule, 'self::topicmeta[parent::topichead]', undefined);
+	configureAsStructure(sxModule, xq`self::topicmeta[parent::topichead]`, undefined);
 
 	// navtitle in topicmeta in topichead
 	configureAsTitleFrame(
 		sxModule,
-		'self::navtitle and parent::topicmeta[parent::topichead]',
+		xq`self::navtitle and parent::topicmeta[parent::topichead]`,
 		undefined,
 		{
 			fontVariation: 'document-title'
@@ -100,8 +101,8 @@ export default function configureSxModule(sxModule) {
 	);
 
 	// topicref
-	configureAsRemoved(sxModule, 'self::topicref', t('link to topic'));
+	configureAsRemoved(sxModule, xq`self::topicref`, t('link to topic'));
 
 	// ux-window
-	configureAsRemoved(sxModule, 'self::ux-window', t('ux-window'));
+	configureAsRemoved(sxModule, xq`self::ux-window`, t('ux-window'));
 }

--- a/packages/dita-example-sx-modules-xsd-mathml-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-mathml-domain/src/configureSxModule.js
@@ -3,6 +3,7 @@ import configureContextualOperations from 'fontoxml-families/src/configureContex
 import configureAsInlineMathMlContainer from 'fontoxml-mathml/src/configureAsInlineMathMlContainer.js';
 import configureAsMathMlContainer from 'fontoxml-mathml/src/configureAsMathMlContainer.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// mathml
@@ -14,17 +15,17 @@ export default function configureSxModule(sxModule) {
 	//     semantically, independent of the format of the equation content. The MathML markup must have a root
 	//     element of "math" within the MathML namespace "http://www.w3.org/1998/Math/MathML". This element is
 	//     part of the DITA MathML domain. Category: Foreign elements
-	configureAsMathMlContainer(sxModule, 'self::mathml', t('mathematical expression'));
-	configureContextualOperations(sxModule, 'self::mathml', [{ name: 'mathml-edit' }]);
+	configureAsMathMlContainer(sxModule, xq`self::mathml`, t('mathematical expression'));
+	configureContextualOperations(sxModule, xq`self::mathml`, [{ name: 'mathml-edit' }]);
 
 	// mathml in inline layout
 	configureAsInlineMathMlContainer(
 		sxModule,
-		'self::mathml[fonto:in-inline-layout(.)]',
+		xq`self::mathml[fonto:in-inline-layout(.)]`,
 		t('mathematical expression')
 	);
 	// The edit operation should be on the container of the mathml element in inline layout
-	configureContextualOperations(sxModule, 'self::mathml[fonto:in-inline-layout(.)]', []);
+	configureContextualOperations(sxModule, xq`self::mathml[fonto:in-inline-layout(.)]`, []);
 
 	// mathmlref
 	//     The MathML reference (<mathmlref>) element is used to refer to a non-DITA XML document containing
@@ -42,5 +43,5 @@ export default function configureSxModule(sxModule) {
 	//     just the key name: <mathml> <mathmlref keyref="mathml-equation-02"/> </mathml> The MathML should be
 	//     processed and rendered as though the <m:math> element had occurred directly in the content of the
 	//     containing <mathml> element. This element is part of the DITA MathML domain. Category: XRef elements
-	configureAsRemoved(sxModule, 'self::mathmlref', t('mathmlref'));
+	configureAsRemoved(sxModule, xq`self::mathmlref`, t('mathmlref'));
 }

--- a/packages/dita-example-sx-modules-xsd-mathml-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-mathml-domain/src/configureSxModule.js
@@ -19,9 +19,10 @@ export default function configureSxModule(sxModule) {
 	configureContextualOperations(sxModule, xq`self::mathml`, [{ name: 'mathml-edit' }]);
 
 	// mathml in inline layout
+	// TODO: Use XQExpressions when configureAsInlineMathMlContainer supports them at 7.18
 	configureAsInlineMathMlContainer(
 		sxModule,
-		xq`self::mathml[fonto:in-inline-layout(.)]`,
+		`self::mathml[fonto:in-inline-layout(.)]`,
 		t('mathematical expression')
 	);
 	// The edit operation should be on the container of the mathml element in inline layout

--- a/packages/dita-example-sx-modules-xsd-programming-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-programming-domain/src/configureSxModule.js
@@ -129,9 +129,10 @@ export default function configureSxModule(sxModule) {
 	//     is designed for documenting programming parameters. This element is part of the DITA programming
 	//     domain, a special set of DITA elements designed to document programming tasks, concepts and
 	//     reference information. Category: Programming elements
+	// TODO add xq to tabNavigationItemSelector when it has been implemented
 	configureAsFrame(sxModule, xq`self::parml`, t('parameter table'), {
 		contextualOperations: [{ name: ':contextual-delete-parml' }],
-		tabNavigationItemSelector: xq`self::pt or self::pd`,
+		tabNavigationItemSelector: `self::pt or self::pd`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});

--- a/packages/dita-example-sx-modules-xsd-programming-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-programming-domain/src/configureSxModule.js
@@ -9,6 +9,7 @@ import configureAsStructure from 'fontoxml-families/src/configureAsStructure.js'
 import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMenuButtonWidget.js';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// apiname
@@ -16,14 +17,14 @@ export default function configureSxModule(sxModule) {
 	//     class name or method name. This element is part of the DITA programming domain, a special set of
 	//     DITA elements designed to document programming tasks, concepts and reference information. Category:
 	//     Programming elements
-	configureAsInlineFrame(sxModule, 'self::apiname', t('API name'));
+	configureAsInlineFrame(sxModule, xq`self::apiname`, t('API name'));
 
 	// codeblock
 	//     The <codeblock> element represents lines of program code. Like the <pre> element, content of this
 	//     element has preserved line endings and is output in a monospaced font. This element is part of the
 	//     DITA programming domain, a special set of DITA elements designed to document programming tasks,
 	//     concepts and reference information. Category: Programming elements
-	configureAsFrameWithBreakableBlock(sxModule, 'self::codeblock', t('code block'), {
+	configureAsFrameWithBreakableBlock(sxModule, xq`self::codeblock`, t('code block'), {
 		backgroundColor: 'brown',
 		contextualOperations: [{ name: ':contextual-unwrap-codeblock' }],
 		emptyElementPlaceholderText: t('type the code'),
@@ -39,7 +40,7 @@ export default function configureSxModule(sxModule) {
 	//     code phrase is displayed in a monospaced font for emphasis. This element is part of the DITA
 	//     programming domain, a special set of DITA elements designed to document programming tasks, concepts
 	//     and reference information. Category: Programming elements
-	configureAsInlineFrame(sxModule, 'self::codeph', t('code phrase'), {
+	configureAsInlineFrame(sxModule, xq`self::codeph`, t('code phrase'), {
 		isMonospaced: true
 	});
 
@@ -48,7 +49,7 @@ export default function configureSxModule(sxModule) {
 	//     the coderef element should cause the target code to be displayed inline. If the target contains
 	//     non-XML characters such as < and &amp;, those will need to be handled in a way that they may be
 	//     displayed correctly by the final rendering engine.
-	configureAsRemoved(sxModule, 'self::coderef', t('code reference'));
+	configureAsRemoved(sxModule, xq`self::coderef`, t('code reference'));
 
 	// delim
 	//     Within a syntax diagram, the delimiter (<delim>) element defines a character marking the beginning
@@ -56,14 +57,14 @@ export default function configureSxModule(sxModule) {
 	//     parenthesis, comma, tab, vertical bar or other special characters. This element is part of the DITA
 	//     programming domain, a special set of DITA elements designed to document programming tasks, concepts
 	//     and reference information. Category: Programming elements
-	configureAsInlineFrame(sxModule, 'self::delim', t('delimiter'));
+	configureAsInlineFrame(sxModule, xq`self::delim`, t('delimiter'));
 
 	// fragment
 	//     Within a syntax definition, a <fragment> is a labeled subpart of the syntax. The <fragment> element
 	//     allows breaking out logical chunks of a large syntax diagram into named fragments. This element is
 	//     part of the DITA programming domain, a special set of DITA elements designed to document programming
 	//     tasks, concepts and reference information. Category: Programming elements
-	configureAsRemoved(sxModule, 'self::fragment', t('fragment'));
+	configureAsRemoved(sxModule, xq`self::fragment`, t('fragment'));
 
 	// fragref
 	//     The fragment reference (<fragref>) element provides a logical reference to a syntax definition
@@ -71,7 +72,7 @@ export default function configureSxModule(sxModule) {
 	//     syntax out of line for easier reading. This element is part of the DITA programming domain, a
 	//     special set of DITA elements designed to document programming tasks, concepts and reference
 	//     information. Category: Programming elements
-	configureAsRemoved(sxModule, 'self::fragref', t('link to fragment'));
+	configureAsRemoved(sxModule, xq`self::fragref`, t('link to fragment'));
 
 	// groupchoice
 	//     The <groupchoice> element is part of the subset of elements that define syntax diagrams in DITA. A
@@ -79,7 +80,7 @@ export default function configureSxModule(sxModule) {
 	//     must make a choice about which part of the syntax to use. Groups are often nested. This element is
 	//     part of the DITA programming domain, a special set of DITA elements designed to document programming
 	//     tasks, concepts and reference information. Category: Programming elements
-	configureAsRemoved(sxModule, 'self::groupchoice', t('group choice'));
+	configureAsRemoved(sxModule, xq`self::groupchoice`, t('group choice'));
 
 	// groupcomp
 	//     The <groupcomp> element is part of the subset of elements that define syntax diagrams in DITA. A
@@ -88,7 +89,7 @@ export default function configureSxModule(sxModule) {
 	//     by a horizontal or vertical line, which is the usual formatting method. This element is part of the
 	//     DITA programming domain, a special set of DITA elements designed to document programming tasks,
 	//     concepts and reference information. Category: Programming elements
-	configureAsRemoved(sxModule, 'self::groupcomp', t('group composite'));
+	configureAsRemoved(sxModule, xq`self::groupcomp`, t('group composite'));
 
 	// groupseq
 	//     The <groupseq> element is part of the subset of elements that define syntax diagrams in DITA. A
@@ -97,14 +98,14 @@ export default function configureSxModule(sxModule) {
 	//     sequence, as delimited by the <groupseq> element. This element is part of the DITA programming
 	//     domain, a special set of DITA elements designed to document programming tasks, concepts and
 	//     reference information. Category: Programming elements
-	configureAsRemoved(sxModule, 'self::groupseq', t('group sequence'));
+	configureAsRemoved(sxModule, xq`self::groupseq`, t('group sequence'));
 
 	// kwd
 	//     The <kwd> element defines a keyword within a syntax diagram. A keyword must be typed or output,
 	//     either by the user or application, exactly as specified in the syntax definition. This element is
 	//     part of the DITA programming domain, a special set of DITA elements designed to document programming
 	//     tasks, concepts and reference information. Category: Programming elements
-	configureAsInlineFrame(sxModule, 'self::kwd', t('keyword'), {
+	configureAsInlineFrame(sxModule, xq`self::kwd`, t('keyword'), {
 		isMonospaced: true
 	});
 
@@ -113,14 +114,14 @@ export default function configureSxModule(sxModule) {
 	//     equals (=), plus (+) or multiply (*). This element is part of the DITA programming domain, a special
 	//     set of DITA elements designed to document programming tasks, concepts and reference information.
 	//     Category: Programming elements
-	configureAsInlineFrame(sxModule, 'self::oper', t('operator'));
+	configureAsInlineFrame(sxModule, xq`self::oper`, t('operator'));
 
 	// option
 	//     The <option> element describes an option that can be used to modify a command (or something else,
 	//     like a configuration). This element is part of the DITA programming domain, a special set of DITA
 	//     elements designed to document programming tasks, concepts and reference information. Category:
 	//     Programming elements
-	configureAsInlineFrame(sxModule, 'self::option', t('option'));
+	configureAsInlineFrame(sxModule, xq`self::option`, t('option'));
 
 	// parml
 	//     The parameter list (<parml>) element contains a list of terms and definitions that describes the
@@ -128,9 +129,9 @@ export default function configureSxModule(sxModule) {
 	//     is designed for documenting programming parameters. This element is part of the DITA programming
 	//     domain, a special set of DITA elements designed to document programming tasks, concepts and
 	//     reference information. Category: Programming elements
-	configureAsFrame(sxModule, 'self::parml', t('parameter table'), {
+	configureAsFrame(sxModule, xq`self::parml`, t('parameter table'), {
 		contextualOperations: [{ name: ':contextual-delete-parml' }],
-		tabNavigationItemSelector: 'self::pt or self::pd',
+		tabNavigationItemSelector: xq`self::pt or self::pd`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -140,20 +141,20 @@ export default function configureSxModule(sxModule) {
 	//     your topic, use the parameter name (<parmname>) element to markup the parameter. This element is
 	//     part of the DITA programming domain, a special set of DITA elements designed to document programming
 	//     tasks, concepts and reference information. Category: Programming elements
-	configureAsInlineFrame(sxModule, 'self::parmname', t('parameter name'));
+	configureAsInlineFrame(sxModule, xq`self::parmname`, t('parameter name'));
 
 	// pd
 	//     A parameter definition, within a parameter list entry, is enclosed by the <pd> element. This element
 	//     is part of the DITA programming domain, a special set of DITA elements designed to document
 	//     programming tasks, concepts and reference information. Category: Programming elements
-	configureAsStructure(sxModule, 'self::pd', t('definition'), {
+	configureAsStructure(sxModule, xq`self::pd`, t('definition'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the definition')
 	});
 
 	configureAsFrame(
 		sxModule,
-		'self::pd[count(preceding-sibling::* | following-sibling::*) > 1]',
+		xq`self::pd[count(preceding-sibling::* | following-sibling::*) > 1]`,
 		t('definition'),
 		{
 			defaultTextContainer: 'p',
@@ -165,7 +166,7 @@ export default function configureSxModule(sxModule) {
 	// p in pd
 	configureAsLine(
 		sxModule,
-		'self::p[parent::pd] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::pd] and not(preceding-sibling::p or following-sibling::p)`,
 		t('paragraph'),
 		{
 			emptyElementPlaceholderText: t('type the definition')
@@ -177,8 +178,8 @@ export default function configureSxModule(sxModule) {
 	//     (pd and pt). This element is part of the DITA programming domain, a special set of DITA elements
 	//     designed to document programming tasks, concepts and reference information. Category: Programming
 	//     elements
-	configureAsDefinitionsTableRow(sxModule, 'self::plentry', t('row'), {
-		columns: [{ query: './pt', width: 1 }, { query: './pd', width: 2 }],
+	configureAsDefinitionsTableRow(sxModule, xq`self::plentry`, t('row'), {
+		columns: [{ query: xq`./pt`, width: 1 }, { query: xq`./pd`, width: 2 }],
 		contextualOperations: [
 			{ name: ':plentry-insert-pt', hideIn: ['breadcrumbs-menu'] },
 			{ name: ':plentry-insert-pd', hideIn: ['breadcrumbs-menu'] },
@@ -193,13 +194,13 @@ export default function configureSxModule(sxModule) {
 	//     A parameter term, within a parameter list entry, is enclosed by the <pt> element. This element is
 	//     part of the DITA programming domain, a special set of DITA elements designed to document programming
 	//     tasks, concepts and reference information. Category: Programming elements
-	configureAsBlock(sxModule, 'self::pt', t('parameter'), {
+	configureAsBlock(sxModule, xq`self::pt`, t('parameter'), {
 		emptyElementPlaceholderText: t('type the parameter')
 	});
 
 	configureAsFrame(
 		sxModule,
-		'self::pt[count(preceding-sibling::* | following-sibling::*) > 1]',
+		xq`self::pt[count(preceding-sibling::* | following-sibling::*) > 1]`,
 		t('parameter'),
 		{
 			emptyElementPlaceholderText: t('type the parameter'),
@@ -213,21 +214,21 @@ export default function configureSxModule(sxModule) {
 	//     (+), this indicates that the character must be used between repetitions of the syntax elements. This
 	//     element is part of the DITA programming domain, a special set of DITA elements designed to document
 	//     programming tasks, concepts and reference information. Category: Programming elements
-	configureAsRemoved(sxModule, 'self::repsep', t('repeat separator'));
+	configureAsRemoved(sxModule, xq`self::repsep`, t('repeat separator'));
 
 	// sep
 	//     The separator (<sep>) element defines a separator character that is inline with the content of a
 	//     syntax diagram. The separator occurs between keywords, operators or groups in a syntax definition.
 	//     This element is part of the DITA programming domain, a special set of DITA elements designed to
 	//     document programming tasks, concepts and reference information. Category: Programming elements
-	configureAsInlineFrame(sxModule, 'self::sep', t('separator'));
+	configureAsInlineFrame(sxModule, xq`self::sep`, t('separator'));
 
 	// synblk
 	//     The syntax block (<synblk>) element organizes small pieces of a syntax definition into a larger
 	//     piece. The syntax block element is part of the DITA programming domain, a special set of DITA
 	//     elements designed to document programming tasks, concepts and reference information. Category:
 	//     Programming elements
-	configureAsRemoved(sxModule, 'self::synblk', t('syntax block'));
+	configureAsRemoved(sxModule, xq`self::synblk`, t('syntax block'));
 
 	// synnote
 	//     The syntax note (<synnote>) element contains a note (similar to a footnote) within a syntax
@@ -236,7 +237,7 @@ export default function configureSxModule(sxModule) {
 	//     at the bottom of the page. The syntax block element is part of the DITA programming domain, a
 	//     special set of DITA elements designed to document programming tasks, concepts and reference
 	//     information. Category: Programming elements
-	configureAsRemoved(sxModule, 'self::synnote', t('syntax note'));
+	configureAsRemoved(sxModule, xq`self::synnote`, t('syntax note'));
 
 	// synnoteref
 	//     The syntax note (<synnoteref>) reference element references a syntax note element (<synnote>) that
@@ -244,7 +245,7 @@ export default function configureSxModule(sxModule) {
 	//     one syntax definition. The syntax note reference element is part of the DITA programming domain, a
 	//     special set of DITA elements designed to document programming tasks, concepts and reference
 	//     information. Category: Programming elements
-	configureAsRemoved(sxModule, 'self::synnoteref', t('syntax note reference'));
+	configureAsRemoved(sxModule, xq`self::synnoteref`, t('syntax note reference'));
 
 	// synph
 	//     The syntax phrase (<synph>) element is a container for syntax definition elements. It is used when a
@@ -252,7 +253,7 @@ export default function configureSxModule(sxModule) {
 	//     are used within the text flow of the topic content. This element is part of the DITA programming
 	//     domain, a special set of DITA elements designed to document programming tasks, concepts and
 	//     reference information. Category: Programming elements
-	configureAsInlineFrame(sxModule, 'self::synph', t('syntax phrase'), {
+	configureAsInlineFrame(sxModule, xq`self::synph`, t('syntax phrase'), {
 		emptyElementPlaceholderText: t('type the syntax')
 	});
 
@@ -264,14 +265,14 @@ export default function configureSxModule(sxModule) {
 	//     presentation may differ depending on the output media. The syntax diagram element is part of the
 	//     DITA programming domain, a special set of DITA elements designed to document programming tasks,
 	//     concepts and reference information. Category: Programming elements
-	configureAsRemoved(sxModule, 'self::syntaxdiagram', t('syntax diagram'));
+	configureAsRemoved(sxModule, xq`self::syntaxdiagram`, t('syntax diagram'));
 
 	// var
 	//     Within a syntax diagram, the <var> element defines a variable for which the user must supply
 	//     content, such as their user name or password. It is represented in output in an italic font. This
 	//     element is part of the DITA programming domain, a special set of DITA elements designed to document
 	//     programming tasks, concepts and reference information. Category: Programming elements
-	configureAsInlineFrame(sxModule, 'self::var', t('variable'), {
+	configureAsInlineFrame(sxModule, xq`self::var`, t('variable'), {
 		slant: 'italic'
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/api/removePropertiesColumnCustomMutation.js
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/api/removePropertiesColumnCustomMutation.js
@@ -1,6 +1,7 @@
 import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult.js';
 import blueprintQuery from 'fontoxml-blueprints/src/blueprintQuery.js';
 import evaluateXPathToNodes from 'fontoxml-selectors/src/evaluateXPathToNodes.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 /**
  * Removes all cells in a column of <properties>.
@@ -26,11 +27,7 @@ export default function removePropertiesColumn(stepData, blueprint) {
 
 	// Query the relevant node names in all rows of the same properties table
 	var columnNodes = evaluateXPathToNodes(
-		'parent::*/parent::properties/*/*[self::' +
-			contextNodeName +
-			' or self::' +
-			otherNodeName +
-			']',
+		xq`parent::*/parent::properties/*/*[self::${contextNodeName} or self::${otherNodeName}]`,
 		contextNode,
 		blueprint
 	);

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/api/removePropertiesColumnCustomMutation.js
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/api/removePropertiesColumnCustomMutation.js
@@ -27,7 +27,7 @@ export default function removePropertiesColumn(stepData, blueprint) {
 
 	// Query the relevant node names in all rows of the same properties table
 	var columnNodes = evaluateXPathToNodes(
-		xq`parent::*/parent::properties/*/*[self::${contextNodeName} or self::${otherNodeName}]`,
+		xq`parent::*/parent::properties/*/*[name() = ${contextNodeName} or name() = ${otherNodeName}]`,
 		contextNode,
 		blueprint
 	);

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.js
@@ -10,12 +10,13 @@ import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMe
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// propdesc
 	//     The <propdesc> element is used to provide a short description of the property type and its listed
 	//     values (or just the value). Category: Reference elements
-	configureAsStructure(sxModule, 'self::propdesc', t('description'), {
+	configureAsStructure(sxModule, xq`self::propdesc`, t('description'), {
 		contextualOperations: [{ name: ':contextual-delete-properties-column' }],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the description')
@@ -24,7 +25,7 @@ export default function configureSxModule(sxModule) {
 	// p in propdesc
 	configureProperties(
 		sxModule,
-		'self::p[parent::propdesc] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::propdesc] and not(preceding-sibling::p or following-sibling::p)`,
 		{
 			emptyElementPlaceholderText: t('type the description')
 		}
@@ -33,7 +34,7 @@ export default function configureSxModule(sxModule) {
 	// propdeschd
 	//     The propdeschd element supports regular headings for the description column of a property table.
 	//     Category: Reference elements
-	configureAsStructure(sxModule, 'self::propdeschd', t('descriptions title'), {
+	configureAsStructure(sxModule, xq`self::propdeschd`, t('descriptions title'), {
 		contextualOperations: [{ name: ':contextual-delete-properties-column' }],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the title for the descriptions')
@@ -42,7 +43,7 @@ export default function configureSxModule(sxModule) {
 	// p in propdeschd
 	configureProperties(
 		sxModule,
-		'self::p[parent::propdeschd] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::propdeschd] and not(preceding-sibling::p or following-sibling::p)`,
 		{
 			emptyElementPlaceholderText: t('type the title for the descriptions')
 		}
@@ -54,10 +55,10 @@ export default function configureSxModule(sxModule) {
 	//     description. The typical rendering is usually in a table-like format. To represent multiple values
 	//     for a type, just create additional property elements and use only the <propvalue> element (and
 	//     <propdesc> when needed) for each successive value. Category: Reference elements
-	configureAsFrame(sxModule, 'self::properties', t('properties'), {
+	configureAsFrame(sxModule, xq`self::properties`, t('properties'), {
 		contextualOperations: [{ name: ':contextual-delete-properties' }],
 		tabNavigationItemSelector:
-			'name() = ("proptypehd", "propvaluehd", "propdeschd", "proptype", "propvalue", "propdesc")',
+			xq`name() = ("proptypehd", "propvaluehd", "propdeschd", "proptype", "propvalue", "propdesc")`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -66,27 +67,27 @@ export default function configureSxModule(sxModule) {
 	//     The <property> element represents a property of the current topic's subject. For example, if the
 	//     current topic is a class, the property might show that the class is protected rather than public. It
 	//     contains three optional elements: type, value, and description. Category: Reference elements
-	configureAsDefinitionsTableRow(sxModule, 'self::property', t('property'), {
+	configureAsDefinitionsTableRow(sxModule, xq`self::property`, t('property'), {
 		columns: [
 			{
-				query: './proptype',
+				query: xq`./proptype`,
 				width: 1,
 				hideColumnIfQueryIsTrue:
-					'parent::properties[not(child::property/proptype) and not(child::prophead/proptypehd)]',
+					xq`parent::properties[not(child::property/proptype) and not(child::prophead/proptypehd)]`,
 				clickOperationWhenEmpty: ':property-insert-proptype'
 			},
 			{
-				query: './propvalue',
+				query: xq`./propvalue`,
 				width: 1,
 				hideColumnIfQueryIsTrue:
-					'parent::properties[not(child::property/propvalue) and not(child::prophead/propvaluehd)]',
+					xq`parent::properties[not(child::property/propvalue) and not(child::prophead/propvaluehd)]`,
 				clickOperationWhenEmpty: ':property-insert-propvalue'
 			},
 			{
-				query: './propdesc',
+				query: xq`./propdesc`,
 				width: 1,
 				hideColumnIfQueryIsTrue:
-					'parent::properties[not(child::property/propdesc) and not(child::prophead/propdeschd)]',
+					xq`parent::properties[not(child::property/propdesc) and not(child::prophead/propdeschd)]`,
 				clickOperationWhenEmpty: ':property-insert-propdesc'
 			}
 		],
@@ -104,27 +105,27 @@ export default function configureSxModule(sxModule) {
 	// prophead
 	//     The prophead element supports regular headings for the properties element. Category: Reference
 	//     elements
-	configureAsDefinitionsTableRow(sxModule, 'self::prophead', t('header'), {
+	configureAsDefinitionsTableRow(sxModule, xq`self::prophead`, t('header'), {
 		columns: [
 			{
-				query: './proptypehd',
+				query: xq`./proptypehd`,
 				width: 1,
 				hideColumnIfQueryIsTrue:
-					'parent::properties[not(child::property/proptype) and not(child::prophead/proptypehd)]',
+					xq`parent::properties[not(child::property/proptype) and not(child::prophead/proptypehd)]`,
 				clickOperationWhenEmpty: ':prophead-insert-proptypehd'
 			},
 			{
-				query: './propvaluehd',
+				query: xq`./propvaluehd`,
 				width: 1,
 				hideColumnIfQueryIsTrue:
-					'parent::properties[not(child::property/propvalue) and not(child::prophead/propvaluehd)]',
+					xq`parent::properties[not(child::property/propvalue) and not(child::prophead/propvaluehd)]`,
 				clickOperationWhenEmpty: ':prophead-insert-propvaluehd'
 			},
 			{
-				query: './propdeschd',
+				query: xq`./propdeschd`,
 				width: 1,
 				hideColumnIfQueryIsTrue:
-					'parent::properties[not(child::property/propdesc) and not(child::prophead/propdeschd)]',
+					xq`parent::properties[not(child::property/propdesc) and not(child::prophead/propdeschd)]`,
 				clickOperationWhenEmpty: ':prophead-insert-propdeschd'
 			}
 		],
@@ -141,7 +142,7 @@ export default function configureSxModule(sxModule) {
 
 	// proptype
 	//     The proptype element describes the type of property. Category: Reference elements
-	configureAsBlock(sxModule, 'self::proptype', t('type'), {
+	configureAsBlock(sxModule, xq`self::proptype`, t('type'), {
 		contextualOperations: [{ name: ':contextual-delete-properties-column' }],
 		emptyElementPlaceholderText: t('type the property type')
 	});
@@ -149,7 +150,7 @@ export default function configureSxModule(sxModule) {
 	// proptypehd
 	//     The proptypehd element supports regular headings for the type column of a property table.
 	//     Category: Reference elements
-	configureAsStructure(sxModule, 'self::proptypehd', t('type title'), {
+	configureAsStructure(sxModule, xq`self::proptypehd`, t('type title'), {
 		contextualOperations: [{ name: ':contextual-delete-properties-column' }],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the title for the property type')
@@ -158,7 +159,7 @@ export default function configureSxModule(sxModule) {
 	// p in proptypehd
 	configureProperties(
 		sxModule,
-		'self::p[parent::proptypehd] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::proptypehd] and not(preceding-sibling::p or following-sibling::p)`,
 		{
 			emptyElementPlaceholderText: t('type the title for the property type')
 		}
@@ -168,7 +169,7 @@ export default function configureSxModule(sxModule) {
 	//     The <propvalue> element indicates the value or values for the current property type. You can put
 	//     values in separate rows if they need separate descriptions, and just leave the <proptype> element
 	//     blank. Category: Reference elements
-	configureAsBlock(sxModule, 'self::propvalue', t('value'), {
+	configureAsBlock(sxModule, xq`self::propvalue`, t('value'), {
 		contextualOperations: [{ name: ':contextual-delete-properties-column' }],
 		emptyElementPlaceholderText: t('type the value')
 	});
@@ -176,7 +177,7 @@ export default function configureSxModule(sxModule) {
 	// propvaluehd
 	//     The propvaluehd element supports regular headings for the value column of a property table.
 	//     Category: Reference elements
-	configureAsStructure(sxModule, 'self::propvaluehd', t('value title'), {
+	configureAsStructure(sxModule, xq`self::propvaluehd`, t('value title'), {
 		contextualOperations: [{ name: ':contextual-delete-properties-column' }],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the title for the property value')
@@ -185,7 +186,7 @@ export default function configureSxModule(sxModule) {
 	// p in propvaluehd
 	configureProperties(
 		sxModule,
-		'self::p[parent::propvaluehd] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::propvaluehd] and not(preceding-sibling::p or following-sibling::p)`,
 		{
 			emptyElementPlaceholderText: t('type the title for the property value')
 		}
@@ -195,7 +196,7 @@ export default function configureSxModule(sxModule) {
 	//     The <refbody> element is a container for the main content of the reference topic. Reference topics
 	//     limit the body structure to tables (both simple and standard), property lists, syntax sections, and
 	//     generic sections and examples, in any sequence or number. Category: Reference elements
-	configureAsStructure(sxModule, 'self::refbody', t('body'), {
+	configureAsStructure(sxModule, xq`self::refbody`, t('body'), {
 		defaultTextContainer: 'section',
 		isRemovableIfEmpty: false
 	});
@@ -203,14 +204,14 @@ export default function configureSxModule(sxModule) {
 	// section in refbody/refbodydiv
 	configureContextualOperations(
 		sxModule,
-		'self::section[(parent::refbody or parent::refbodydiv) and child::*[not(self::table or self::simpletable)]]',
+		xq`self::section[(parent::refbody or parent::refbodydiv) and child::*[not(self::table or self::simpletable)]]`,
 		[{ name: ':section-insert-title' }, { name: ':contextual-delete-section' }]
 	);
 
 	// example in refbody/refbodydiv
 	configureContextualOperations(
 		sxModule,
-		'self::example[(parent::refbody or parent::refbodydiv) and child::*[not(self::table or self::simpletable)]]',
+		xq`self::example[(parent::refbody or parent::refbodydiv) and child::*[not(self::table or self::simpletable)]]`,
 		[{ name: ':example-insert-title' }, { name: ':contextual-delete-example' }]
 	);
 
@@ -221,7 +222,7 @@ export default function configureSxModule(sxModule) {
 	//     restrictions by only allowing elements that are already available within the body of a reference.
 	//     There are no additional semantics attached to the <refbodydiv> element; it is purely a grouping
 	//     element provided to help organize content.
-	configureAsFrame(sxModule, 'self::refbodydiv', t('body division'), {
+	configureAsFrame(sxModule, xq`self::refbodydiv`, t('body division'), {
 		contextualOperations: [{ name: ':contextual-unwrap-refbodydiv' }],
 		defaultTextContainer: 'section',
 		emptyElementPlaceholderText: t('type the content'),
@@ -240,14 +241,14 @@ export default function configureSxModule(sxModule) {
 	//     general rules that apply to all kinds of reference information, using elements like <refsyn> for
 	//     syntax or signatures, and <properties> for lists of properties and values. Category: Reference
 	//     elements
-	configureAsSheetFrame(sxModule, 'self::reference', t('reference'), {
+	configureAsSheetFrame(sxModule, xq`self::reference`, t('reference'), {
 		defaultTextContainer: 'refbody',
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -256,17 +257,17 @@ export default function configureSxModule(sxModule) {
 	// reference nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::reference[parent::*[fonto:dita-class(., "topic/topic")]]',
+		xq`self::reference[parent::*[fonto:dita-class(., "topic/topic")]]`,
 		undefined,
 		{
 			defaultTextContainer: 'refbody',
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in reference
-	configureAsTitleFrame(sxModule, 'self::title[parent::reference]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::reference]`, undefined, {
 		fontVariation: 'document-title'
 	});
 
@@ -275,26 +276,26 @@ export default function configureSxModule(sxModule) {
 	//     syntax or signature content (for example, a command-line utility's calling syntax, or an API's
 	//     signature). The <refsyn> contains a brief, possibly diagrammatic description of the subject's
 	//     interface or high-level structure. Category: Reference elements
-	configureAsFrame(sxModule, 'self::refsyn', t('reference syntax'), {
+	configureAsFrame(sxModule, xq`self::refsyn`, t('reference syntax'), {
 		contextualOperations: [
 			{ name: ':refsyn-insert-title' },
 			{ name: ':contextual-unwrap-refsyn' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the syntax'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	configureContextualOperations(
 		sxModule,
-		'self::refsyn[(parent::refbody or parent::refbodydiv) and child::*[not(self::table or self::simpletable)]]',
+		xq`self::refsyn[(parent::refbody or parent::refbodydiv) and child::*[not(self::table or self::simpletable)]]`,
 		[{ name: ':refsyn-insert-title' }, { name: ':contextual-delete-refsyn' }]
 	);
 
 	// title in refsyn
-	configureAsTitleFrame(sxModule, 'self::title[parent::refsyn]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::refsyn]`, undefined, {
 		fontVariation: 'section-title'
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.js
@@ -55,10 +55,11 @@ export default function configureSxModule(sxModule) {
 	//     description. The typical rendering is usually in a table-like format. To represent multiple values
 	//     for a type, just create additional property elements and use only the <propvalue> element (and
 	//     <propdesc> when needed) for each successive value. Category: Reference elements
+	// TODO add xq to tabNavigationItemSelector when it has been implemented
 	configureAsFrame(sxModule, xq`self::properties`, t('properties'), {
 		contextualOperations: [{ name: ':contextual-delete-properties' }],
 		tabNavigationItemSelector:
-			xq`name() = ("proptypehd", "propvaluehd", "propdeschd", "proptype", "propvalue", "propdesc")`,
+			`name() = ("proptypehd", "propvaluehd", "propdeschd", "proptype", "propvalue", "propdesc")`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/install.js
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/install.js
@@ -30,11 +30,11 @@ export default function install() {
 			var isFirstCell = true;
 			stepData.childNodeStructure = [stepData.rowNodeName];
 			stepData.columns.forEach(function(column) {
-				var selector = 'child::*/' + column.currentNodeName;
-				selector += column.otherNodeNames
-					? ' or child::*/' + column.otherNodeNames.join(' or child::*/')
-					: '';
-				if (!evaluateXPathToBoolean(xq(selector), tableNode, readOnlyBlueprint)) {
+				if (!evaluateXPathToBoolean(xq`child::*/child::*[name() = ${column.currentNodeName}]`, tableNode, readOnlyBlueprint)) {
+					return;
+				}
+			
+				if (column.otherNodeNames && column.otherNodeNames.some(nodeName => evaluateXPathToBoolean(xq`child::*/child::*[name() = ${nodeName}]`, tableNode, readOnlyBlueprint))) {
 					return;
 				}
 

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/install.js
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/install.js
@@ -3,20 +3,20 @@ import readOnlyBlueprint from 'fontoxml-blueprints/src/readOnlyBlueprint.js';
 import documentsManager from 'fontoxml-documents/src/documentsManager.js';
 import addTransform from 'fontoxml-operations/src/addTransform.js';
 import evaluateXPathToBoolean from 'fontoxml-selectors/src/evaluateXPathToBoolean.js';
-import evaluateXPathToFirstNode from 'fontoxml-selectors/src/evaluateXPathToFirstNode.js';
 import removePropertiesColumn from './api/removePropertiesColumnCustomMutation.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function install() {
 	addCustomMutation('remove-properties-column', removePropertiesColumn);
 
 	/**
 	 * Prepares the `childNodeStructure` operation data for inserting a new row in a <properties>-like table.
-	 * @param  {Object} stepData
-	 * @param  {NodeId}  stepData.tableNodeId
-	 * @param  {string}  stepData.rowNodeName
-	 * @param  {Object}  stepData.columns
-	 * @param  {string[]}  stepData.columns.otherNodeNames
-	 * @param  {string}  stepData.columns.currentNodeName
+	 * @param  {Object}     stepData
+	 * @param  {NodeId}     stepData.tableNodeId
+	 * @param  {string}     stepData.rowNodeName
+	 * @param  {Object}     stepData.columns
+	 * @param  {string[]}   stepData.columns.otherNodeNames
+	 * @param  {string}     stepData.columns.currentNodeName
 	 * @return {{ childNodeStructure: Stencil }}
 	 */
 	addTransform(
@@ -29,13 +29,13 @@ export default function install() {
 
 			var isFirstCell = true;
 			stepData.childNodeStructure = [stepData.rowNodeName];
-
+			// TODO concats 
 			stepData.columns.forEach(function(column) {
 				var selector = 'child::*/' + column.currentNodeName;
 				selector += column.otherNodeNames
 					? ' or child::*/' + column.otherNodeNames.join(' or child::*/')
 					: '';
-				if (!evaluateXPathToBoolean(selector, tableNode, readOnlyBlueprint)) {
+				if (!evaluateXPathToBoolean(xq(selector), tableNode, readOnlyBlueprint)) {
 					return;
 				}
 

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/install.js
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/install.js
@@ -29,7 +29,6 @@ export default function install() {
 
 			var isFirstCell = true;
 			stepData.childNodeStructure = [stepData.rowNodeName];
-			// TODO concats 
 			stepData.columns.forEach(function(column) {
 				var selector = 'child::*/' + column.currentNodeName;
 				selector += column.otherNodeNames

--- a/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.js
@@ -106,9 +106,10 @@ export default function configureSxModule(sxModule) {
 	// choicetable
 	//     The <choicetable> element contains a series of optional choices available within a step of a task.
 	//     Category: Task elements
+	// TODO add xq to tabNavigationItemSelector when it has been implemented
 	configureAsFrame(sxModule, xq`self::choicetable`, t('choice table'), {
 		contextualOperations: [{ name: ':contextual-delete-choicetable' }],
-		tabNavigationItemSelector: xq`name() = ("choptionhd", "chdeschd", "choption", "chdesc")`,
+		tabNavigationItemSelector: `name() = ("choptionhd", "chdeschd", "choption", "chdesc")`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});

--- a/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.js
@@ -14,13 +14,14 @@ import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidg
 import createNumberingWidget from 'fontoxml-families/src/createNumberingWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// chdesc
 	//     The <chdesc> element is a description of an option that a user chooses while performing a step to
 	//     accomplish a task. It explains why the user would choose that option, and might explain the result
 	//     of the choice when it is not immediately obvious. Category: Task elements
-	configureAsStructure(sxModule, 'self::chdesc', t('description'), {
+	configureAsStructure(sxModule, xq`self::chdesc`, t('description'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the description')
 	});
@@ -28,7 +29,7 @@ export default function configureSxModule(sxModule) {
 	// p in chdesc
 	configureAsBlock(
 		sxModule,
-		'self::p[parent::chdesc] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::chdesc] and not(preceding-sibling::p or following-sibling::p)`,
 		t('paragraph'),
 		{
 			emptyElementPlaceholderText: t('type the description')
@@ -39,7 +40,7 @@ export default function configureSxModule(sxModule) {
 	//     The <chdeschd> option provides a specific label for the list of descriptions of options that a user
 	//     must choose to accomplish a step of a task. The default label overridden by <chdeschd> is
 	//     Description. Category: Task elements
-	configureAsStructure(sxModule, 'self::chdeschd', t('title'), {
+	configureAsStructure(sxModule, xq`self::chdeschd`, t('title'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the title for the descriptions')
 	});
@@ -47,7 +48,7 @@ export default function configureSxModule(sxModule) {
 	// p in chdeschd
 	configureAsBlock(
 		sxModule,
-		'self::p[parent::chdeschd] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::chdeschd] and not(preceding-sibling::p or following-sibling::p)`,
 		t('paragraph'),
 		{
 			emptyElementPlaceholderText: t('type the title for the descriptions')
@@ -58,8 +59,8 @@ export default function configureSxModule(sxModule) {
 	//     The <chhead> element is a container inside the <choicetable> element that provides specific heading
 	//     text to override the default Options and Description headings. The <chhead> element contains both a
 	//     <choptionhd> and <chdeschd> element as a pair. Category: Task elements
-	configureAsDefinitionsTableRow(sxModule, 'self::chhead', t('header'), {
-		columns: [{ query: './choptionhd', width: 1 }, { query: './chdeschd', width: 2 }],
+	configureAsDefinitionsTableRow(sxModule, xq`self::chhead`, t('header'), {
+		columns: [{ query: xq`./choptionhd`, width: 1 }, { query: xq`./chdeschd`, width: 2 }],
 		borders: true,
 		backgroundColor: 'black',
 		showWhen: 'always',
@@ -69,23 +70,23 @@ export default function configureSxModule(sxModule) {
 	// choice
 	//     Each <choice> element describes one way that the user could accomplish the current step. Category:
 	//     Task elements
-	configureAsGroup(sxModule, 'self::choice', t('choice'), {
+	configureAsGroup(sxModule, xq`self::choice`, t('choice'), {
 		contextualOperations: [
 			{ name: ':contextual-insert-choice--above' },
 			{ name: ':contextual-insert-choice--below' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('describe a choice for this step'),
-		blockBefore: [createLabelQueryWidget('"\u25cf"')]
+		blockBefore: [createLabelQueryWidget(xq`"\u25cf"`)]
 	});
 
 	// p in choice
-	configureAsLine(sxModule, 'self::p[parent::choice]', t('paragraph'));
+	configureAsLine(sxModule, xq`self::p[parent::choice]`, t('paragraph'));
 
 	// p(only) in choice
 	configureAsLine(
 		sxModule,
-		'self::p[parent::choice] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::choice] and not(preceding-sibling::p or following-sibling::p)`,
 		t('paragraph'),
 		{
 			emptyElementPlaceholderText: t('describe a choice for this step')
@@ -95,7 +96,7 @@ export default function configureSxModule(sxModule) {
 	// choices
 	//     The <choices> element contains a list of <choice> elements. It is used when the user will need to
 	//     choose one of several actions while performing the steps of a task. Category: Task elements
-	configureAsFrame(sxModule, 'self::choices', t('choice list'), {
+	configureAsFrame(sxModule, xq`self::choices`, t('choice list'), {
 		defaultTextContainer: 'choice',
 		expression: 'compact',
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -104,9 +105,9 @@ export default function configureSxModule(sxModule) {
 	// choicetable
 	//     The <choicetable> element contains a series of optional choices available within a step of a task.
 	//     Category: Task elements
-	configureAsFrame(sxModule, 'self::choicetable', t('choice table'), {
+	configureAsFrame(sxModule, xq`self::choicetable`, t('choice table'), {
 		contextualOperations: [{ name: ':contextual-delete-choicetable' }],
-		tabNavigationItemSelector: 'name() = ("choptionhd", "chdeschd", "choption", "chdesc")',
+		tabNavigationItemSelector: xq`name() = ("choptionhd", "chdeschd", "choption", "chdesc")`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
@@ -114,7 +115,7 @@ export default function configureSxModule(sxModule) {
 	// choption
 	//     The <choption> element describes an option that a user could choose to accomplish a step of a task.
 	//     In a user interface, for example, this might be the name of radio button. Category: Task elements
-	configureAsStructure(sxModule, 'self::choption', t('option'), {
+	configureAsStructure(sxModule, xq`self::choption`, t('option'), {
 		emptyElementPlaceholderText: t('type the option'),
 		defaultTextContainer: 'p'
 	});
@@ -122,7 +123,7 @@ export default function configureSxModule(sxModule) {
 	// p in choption
 	configureAsBlock(
 		sxModule,
-		'self::p[parent::choption] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::choption] and not(preceding-sibling::p or following-sibling::p)`,
 		t('paragraph'),
 		{
 			emptyElementPlaceholderText: t('type the option')
@@ -132,7 +133,7 @@ export default function configureSxModule(sxModule) {
 	// choptionhd
 	//     The <choptionhd> element provides a specific label for the list of options that a user chooses from
 	//     to accomplish a step. The default label for options is Option. Category: Task elements
-	configureAsStructure(sxModule, 'self::choptionhd', t('title'), {
+	configureAsStructure(sxModule, xq`self::choptionhd`, t('title'), {
 		emptyElementPlaceholderText: t('type the title for the options'),
 		defaultTextContainer: 'p'
 	});
@@ -140,7 +141,7 @@ export default function configureSxModule(sxModule) {
 	// p in choptionhd
 	configureAsBlock(
 		sxModule,
-		'self::p[parent::choptionhd] and not(preceding-sibling::p or following-sibling::p)',
+		xq`self::p[parent::choptionhd] and not(preceding-sibling::p or following-sibling::p)`,
 		t('paragraph'),
 		{
 			emptyElementPlaceholderText: t('type the title for the options')
@@ -150,8 +151,8 @@ export default function configureSxModule(sxModule) {
 	// chrow
 	//     The <chrow> element is a container inside the <choicetable> element. The <chrow> element contains
 	//     both a <choption> and <chdesc> element as a pair. Category: Task elements
-	configureAsDefinitionsTableRow(sxModule, 'self::chrow', t('row'), {
-		columns: [{ query: './choption', width: 1 }, { query: './chdesc', width: 2 }],
+	configureAsDefinitionsTableRow(sxModule, xq`self::chrow`, t('row'), {
+		columns: [{ query: xq`./choption`, width: 1 }, { query: xq`./chdesc`, width: 2 }],
 		contextualOperations: [
 			{ name: ':contextual-insert-chrow--above' },
 			{ name: ':contextual-insert-chrow--below' },
@@ -165,7 +166,7 @@ export default function configureSxModule(sxModule) {
 	//     voice instruction to the user for completing the step, and should not be more than one sentence. If
 	//     the step needs additional explanation, this can follow the <cmd> element inside an <info > element.
 	//     Category: Task elements
-	configureAsLine(sxModule, 'self::cmd', t('command'), {
+	configureAsLine(sxModule, xq`self::cmd`, t('command'), {
 		emptyElementPlaceholderText: t('type a single sentence instruction')
 	});
 
@@ -174,7 +175,7 @@ export default function configureSxModule(sxModule) {
 	//     the user understand what the purpose of the task is and what they will gain by completing the task.
 	//     This section should be brief and does not replace or recreate a concept topic on the same subject,
 	//     although the context section may include some conceptual information. Category: Task elements
-	configureAsFrame(sxModule, 'self::context', t('context'), {
+	configureAsFrame(sxModule, xq`self::context`, t('context'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type a context for this task'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -183,7 +184,7 @@ export default function configureSxModule(sxModule) {
 	// info
 	//     The information element (<info>) occurs inside a <step> element to provide additional information
 	//     about the step. Category: Task elements
-	configureAsFrame(sxModule, 'self::info', t('information'), {
+	configureAsFrame(sxModule, xq`self::info`, t('information'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type additional information for this step'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -193,7 +194,7 @@ export default function configureSxModule(sxModule) {
 	//     The <postreq> element describes steps or tasks that the user should do after the successful
 	//     completion of the current task. It is often supported by links to the next task or tasks in the
 	//     <related-links> section. Category: Task elements
-	configureAsFrame(sxModule, 'self::postreq', t('postrequisites'), {
+	configureAsFrame(sxModule, xq`self::postreq`, t('postrequisites'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the postrequisites for this task'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -204,7 +205,7 @@ export default function configureSxModule(sxModule) {
 	//     before starting the current task. Prerequisite links will be placed in a list after the
 	//     related-links section; on output the <prereq> links from the related-links section are added to the
 	//     <prereq> section. Category: Task elements
-	configureAsFrame(sxModule, 'self::prereq', t('prerequisites'), {
+	configureAsFrame(sxModule, xq`self::prereq`, t('prerequisites'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the prerequisites for this task'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -212,7 +213,7 @@ export default function configureSxModule(sxModule) {
 
 	// result
 	//     The <result> element describes the expected outcome for the task as a whole. Category: Task elements
-	configureAsFrame(sxModule, 'self::result', t('result'), {
+	configureAsFrame(sxModule, xq`self::result`, t('result'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type a result for this task'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -224,7 +225,7 @@ export default function configureSxModule(sxModule) {
 	//     accomplish the overall task. The step element can also contain information <info>, substeps
 	//     <substeps>, tutorial information <tutorialinfo>, a step example <stepxmp>, choices <choices> or a
 	//     stepresult <stepresult>, although these are optional. Category: Task elements
-	configureAsGroup(sxModule, 'self::step', t('step'), {
+	configureAsGroup(sxModule, xq`self::step`, t('step'), {
 		contextualOperations: [
 			{ name: ':contextual-insert-note', hideIn: ['breadcrumbs-menu'] },
 			{ name: ':contextual-insert-info', hideIn: ['breadcrumbs-menu'] },
@@ -242,10 +243,10 @@ export default function configureSxModule(sxModule) {
 			{ name: ':contextual-delete-step' }
 		],
 		defaultTextContainer: 'cmd',
-		titleQuery: './cmd',
+		titleQuery: xq`./cmd`,
 		blockBefore: [
-			createNumberingWidget('self::step', {
-				containerSelectorOrNodeSpec: 'self::steps',
+			createNumberingWidget(xq`self::step`, {
+				containerSelectorOrNodeSpec: xq`self::steps`,
 				prefix: 'step'
 			})
 		],
@@ -253,9 +254,9 @@ export default function configureSxModule(sxModule) {
 	});
 
 	// step in steps-unordered
-	configureAsGroup(sxModule, 'self::step[parent::steps-unordered]', t('step'), {
+	configureAsGroup(sxModule, xq`self::step[parent::steps-unordered]`, t('step'), {
 		defaultTextContainer: 'cmd',
-		titleQuery: './cmd',
+		titleQuery: xq`./cmd`,
 		blockBefore: [createLabelWidget('step')],
 		blockBeforeWidth: 'wide'
 	});
@@ -282,7 +283,7 @@ export default function configureSxModule(sxModule) {
 	}
 	configureContextualOperations(
 		sxModule,
-		'self::note[parent::step or parent::substep]',
+		xq`self::note[parent::step or parent::substep]`,
 		getContextualOperationsForNoteType('@type=null')
 	);
 	[
@@ -300,7 +301,7 @@ export default function configureSxModule(sxModule) {
 	].forEach(function(noteType) {
 		configureContextualOperations(
 			sxModule,
-			'self::note[@type="' + noteType + '" and (parent::step or parent::substep)]',
+			xq`self::note[@type=${noteType} and (parent::step or parent::substep)]`,
 			getContextualOperationsForNoteType(noteType)
 		);
 	});
@@ -310,7 +311,7 @@ export default function configureSxModule(sxModule) {
 	//     is being documented, the outcome could describe a dialog box opening, or the appearance of a
 	//     progress indicator. Step results are useful to assure a user that they are on track, but should not
 	//     be used for every step, as this quickly becomes tedious. Category: Task elements
-	configureAsFrame(sxModule, 'self::stepresult', t('result'), {
+	configureAsFrame(sxModule, xq`self::stepresult`, t('result'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type a result for this step'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -320,7 +321,7 @@ export default function configureSxModule(sxModule) {
 	//     The <steps> section of a task provides the main content of the task topic. The task is described as
 	//     a series of steps that the user must follow to accomplish the task. One or more <steps> elements is
 	//     required inside the <steps> section. Category: Task elements
-	configureAsGroup(sxModule, 'self::steps', t('ordered steps'), {
+	configureAsGroup(sxModule, xq`self::steps`, t('ordered steps'), {
 		contextualOperations: [
 			{ name: ':steps-convert-to-steps-unordered' },
 			{ name: ':contextual-replace-with-steps-informal' }
@@ -330,7 +331,7 @@ export default function configureSxModule(sxModule) {
 	});
 
 	// steps-informal
-	configureAsFrame(sxModule, 'self::steps-informal', t('informal steps'), {
+	configureAsFrame(sxModule, xq`self::steps-informal`, t('informal steps'), {
 		contextualOperations: [
 			{ name: ':steps-informal-replace-with-steps' },
 			{ name: ':steps-informal-replace-with-steps-unordered' }
@@ -344,7 +345,7 @@ export default function configureSxModule(sxModule) {
 	//     Like the <steps> element, the <steps-unordered> section of a task provides the main content of the
 	//     task topic, but particularly for cases in which the order of steps may vary from one situation to
 	//     another. One or more steps is required inside the <steps-unordered> section. Category: Task elements
-	configureAsGroup(sxModule, 'self::steps-unordered', t('unordered steps'), {
+	configureAsGroup(sxModule, xq`self::steps-unordered`, t('unordered steps'), {
 		contextualOperations: [
 			{ name: ':steps-unordered-convert-to-steps' },
 			{ name: ':contextual-replace-with-steps-informal' }
@@ -354,7 +355,7 @@ export default function configureSxModule(sxModule) {
 	});
 
 	// stepsection
-	configureAsGroup(sxModule, 'self::stepsection', t('step section'), {
+	configureAsGroup(sxModule, xq`self::stepsection`, t('step section'), {
 		contextualOperations: [
 			{ name: ':contextual-insert-step--above' },
 			{ name: ':contextual-insert-step--below' }
@@ -367,7 +368,7 @@ export default function configureSxModule(sxModule) {
 
 	// steptroubleshooting
 	//     Category: Task elements
-	configureAsFrame(sxModule, 'self::steptroubleshooting', t('troubleshooting'), {
+	configureAsFrame(sxModule, xq`self::steptroubleshooting`, t('troubleshooting'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type troubleshooting information for this step'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -376,7 +377,7 @@ export default function configureSxModule(sxModule) {
 	// stepxmp
 	//     The step example (<stepxmp>) element is used to illustrate a step of a task. The example can be a
 	//     couple of words, or an entire paragraph. Category: Task elements
-	configureAsFrame(sxModule, 'self::stepxmp', t('example'), {
+	configureAsFrame(sxModule, xq`self::stepxmp`, t('example'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type an example for this step'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -386,7 +387,7 @@ export default function configureSxModule(sxModule) {
 	//     A <substep> element has the same structure as a <step>, except that it does not allow lists of
 	//     choices or substeps within it, in order to prevent unlimited nesting of steps. Category: Task
 	//     elements
-	configureAsGroup(sxModule, 'self::substep', t('substep'), {
+	configureAsGroup(sxModule, xq`self::substep`, t('substep'), {
 		contextualOperations: [
 			{ name: ':contextual-insert-note', hideIn: ['breadcrumbs-menu'] },
 			{ name: ':contextual-insert-info', hideIn: ['breadcrumbs-menu'] },
@@ -398,11 +399,11 @@ export default function configureSxModule(sxModule) {
 			{ name: ':contextual-delete-substep' }
 		],
 		defaultTextContainer: 'cmd',
-		titleQuery: './cmd',
+		titleQuery: xq`./cmd`,
 		blockBefore: [
-			createNumberingWidget('self::substep', {
+			createNumberingWidget(xq`self::substep`, {
 				numberingStyle: 'lowerAlpha',
-				containerSelectorOrNodeSpec: 'self::substeps',
+				containerSelectorOrNodeSpec: xq`self::substeps`,
 				prefix: 'step'
 			})
 		],
@@ -412,11 +413,11 @@ export default function configureSxModule(sxModule) {
 	// substep in steps-unordered
 	configureAsGroup(
 		sxModule,
-		'self::substep[parent::substeps[parent::step[parent::steps-unordered]]]',
+		xq`self::substep[parent::substeps[parent::step[parent::steps-unordered]]]`,
 		t('substep'),
 		{
 			defaultTextContainer: 'cmd',
-			titleQuery: './cmd',
+			titleQuery: xq`./cmd`,
 			blockBefore: [createLabelWidget('step')],
 			blockBeforeWidth: 'wide'
 		}
@@ -427,7 +428,7 @@ export default function configureSxModule(sxModule) {
 	//     be used only if necessary. Try to describe the steps of a task in a single level of steps. If you
 	//     need to use more than one level of substep nesting, you should probably rewrite the task to simplify
 	//     it. Category: Task elements
-	configureAsGroup(sxModule, 'self::substeps', t('substeps'), {
+	configureAsGroup(sxModule, xq`self::substeps`, t('substeps'), {
 		defaultTextContainer: 'substep',
 		isIgnoredForNavigation: false
 	});
@@ -438,15 +439,15 @@ export default function configureSxModule(sxModule) {
 	//     user to perform a task. A task answers the question of "how to?" by telling the user precisely what
 	//     to do and the order in which to do it. Tasks have the same high-level structure as other topics,
 	//     with a title, short description and body. Category: Task elements
-	configureAsSheetFrame(sxModule, 'self::task', t('task'), {
+	configureAsSheetFrame(sxModule, xq`self::task`, t('task'), {
 		defaultTextContainer: 'taskbody',
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		]
 	});
@@ -454,17 +455,17 @@ export default function configureSxModule(sxModule) {
 	// task nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::task[parent::*[fonto:dita-class(., "topic/topic")]]',
+		xq`self::task[parent::*[fonto:dita-class(., "topic/topic")]]`,
 		undefined,
 		{
 			defaultTextContainer: 'taskbody',
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in task
-	configureAsTitleFrame(sxModule, 'self::title[parent::task]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::task]`, undefined, {
 		fontVariation: 'document-title'
 	});
 
@@ -472,20 +473,20 @@ export default function configureSxModule(sxModule) {
 	//     The <taskbody> element is the main body-level element inside a task topic. A task body has a very
 	//     specific structure, with the following elements in this order: <prereq>, <context>, <steps>,
 	//     <result>, <example> and <postreq>. Each of the body sections are optional. Category: Task elements
-	configureAsStructure(sxModule, 'self::taskbody', t('body'), {
+	configureAsStructure(sxModule, xq`self::taskbody`, t('body'), {
 		defaultTextContainer: 'prereq',
 		isRemovableIfEmpty: false
 	});
 
 	// example in taskbody
-	configureContextualOperations(sxModule, 'self::example[parent::taskbody]', [
+	configureContextualOperations(sxModule, xq`self::example[parent::taskbody]`, [
 		{ name: ':example-insert-title' },
 		{ name: ':contextual-delete-example' }
 	]);
 
 	// tasktroubleshooting
 	//     Category: Task elements
-	configureAsFrame(sxModule, 'self::tasktroubleshooting', t('troubleshooting'), {
+	configureAsFrame(sxModule, xq`self::tasktroubleshooting`, t('troubleshooting'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type troubleshooting information for this task'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -494,7 +495,7 @@ export default function configureSxModule(sxModule) {
 	// tutorialinfo
 	//     The tutorial info (<tutorialinfo>) element contains additional information that is useful when the
 	//     task is part of a tutorial. Category: Task elements
-	configureAsFrame(sxModule, 'self::tutorialinfo', t('tutorial information'), {
+	configureAsFrame(sxModule, xq`self::tutorialinfo`, t('tutorial information'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type additional tutorial information'),
 		blockHeaderLeft: [createMarkupLabelWidget()]

--- a/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.js
@@ -70,6 +70,7 @@ export default function configureSxModule(sxModule) {
 	// choice
 	//     Each <choice> element describes one way that the user could accomplish the current step. Category:
 	//     Task elements
+	// TODO: Upgrade the createLabelQueryWidget when it accepts XQuery template tags in 7.18
 	configureAsGroup(sxModule, xq`self::choice`, t('choice'), {
 		contextualOperations: [
 			{ name: ':contextual-insert-choice--above' },
@@ -77,7 +78,7 @@ export default function configureSxModule(sxModule) {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('describe a choice for this step'),
-		blockBefore: [createLabelQueryWidget(xq`"\u25cf"`)]
+		blockBefore: [createLabelQueryWidget(`"\u25cf"`)]
 	});
 
 	// p in choice

--- a/packages/dita-example-sx-modules-xsd-tbl-decl-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-tbl-decl-mod/src/configureSxModule.js
@@ -66,9 +66,10 @@ export default function configureSxModule(sxModule) {
 	// tgroup
 	//     The <tgroup> element in a table contains column, row, spanning, header and footer specifications,
 	//     and the body (<tbody>) of the table. Category: Table elements
+	// TODO add xq to tabNavigationItemSelector when it has been implemented
 	configureProperties(sxModule, xq`self::tgroup`, {
 		markupLabel: t('table'),
-		tabNavigationItemSelector: xq`self::entry`
+		tabNavigationItemSelector: `self::entry`
 	});
 
 	// thead

--- a/packages/dita-example-sx-modules-xsd-tbl-decl-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-tbl-decl-mod/src/configureSxModule.js
@@ -3,6 +3,7 @@ import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMe
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import t from 'fontoxml-localization/src/t.js';
 import configureAsCalsTableElements from 'fontoxml-table-flow-cals/src/configureAsCalsTableElements.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// CALS table
@@ -20,18 +21,18 @@ export default function configureSxModule(sxModule) {
 	// colspec
 	//     The <colspec> element contains a column specification for a table, including assigning a column name
 	//     and number, cell content alignment, and column width. Category: Table elements
-	configureProperties(sxModule, 'self::colspec', {
+	configureProperties(sxModule, xq`self::colspec`, {
 		markupLabel: t('columns')
 	});
 
 	// entry
 	//     The <entry> element defines a single cell in a table. Category: Table elements
-	configureProperties(sxModule, 'self::entry', {
+	configureProperties(sxModule, xq`self::entry`, {
 		markupLabel: t('cell')
 	});
 	configureProperties(
 		sxModule,
-		'self::entry[fonto:get-column-index(.) = 0 and ancestor::table[1][@rowheader="firstcol"]]',
+		xq`self::entry[fonto:get-column-index(.) = 0 and ancestor::table[1][@rowheader="firstcol"]]`,
 		{
 			backgroundColor: 'black'
 		}
@@ -39,41 +40,41 @@ export default function configureSxModule(sxModule) {
 
 	// row
 	//     The <row> element contains a single row in a table <tgroup>. Category: Table elements
-	configureProperties(sxModule, 'self::row', {
+	configureProperties(sxModule, xq`self::row`, {
 		markupLabel: t('row')
 	});
 
 	// table
-	configureProperties(sxModule, 'self::table', {
+	configureProperties(sxModule, xq`self::table`, {
 		contextualOperations: [
 			{ name: 'cals-open-table-column-sizing-popover' },
 			{ name: ':cals-table-insert-title' },
 			{ name: ':cals-table-insert-desc' }
 		],
 		markupLabel: t('table figure'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// tbody
 	//     The <tbody> element contains the rows in a table. Category: Table elements
-	configureProperties(sxModule, 'self::tbody', {
+	configureProperties(sxModule, xq`self::tbody`, {
 		markupLabel: t('body')
 	});
 
 	// tgroup
 	//     The <tgroup> element in a table contains column, row, spanning, header and footer specifications,
 	//     and the body (<tbody>) of the table. Category: Table elements
-	configureProperties(sxModule, 'self::tgroup', {
+	configureProperties(sxModule, xq`self::tgroup`, {
 		markupLabel: t('table'),
-		tabNavigationItemSelector: 'self::entry'
+		tabNavigationItemSelector: xq`self::entry`
 	});
 
 	// thead
 	//     The table header (<thead>) element precedes the table body (<tbody>) element in a complex table.
 	//     Category: Table elements
-	configureProperties(sxModule, 'self::thead', {
+	configureProperties(sxModule, xq`self::thead`, {
 		markupLabel: t('header')
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-topic-mod/src/configureRelatedLinkToUsePermanentId.js
+++ b/packages/dita-example-sx-modules-xsd-topic-mod/src/configureRelatedLinkToUsePermanentId.js
@@ -1,13 +1,14 @@
 import configureAsRelatedLink from 'fontoxml-dita/src/configureAsRelatedLink.js';
 import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMenuButtonWidget.js';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureXrefToUsePermanentId(sxModule) {
 	// To enable permanentId's in references (also known as the reference pipeline), change
 	// hasPermanentId to TRUE, and set popoverData.targetIsPermanent to TRUE.
 
 	// A cross link. (cross link is used by default)
-	configureAsRelatedLink(sxModule, 'self::link', undefined, {
+	configureAsRelatedLink(sxModule, xq`self::link`, undefined, {
 		contextualOperations: [{ name: ':link-insert-linktext' }, { name: ':link-insert-desc' }],
 		backgroundColor: 'grey',
 		defaultTextContainer: 'linktext',
@@ -16,7 +17,7 @@ export default function configureXrefToUsePermanentId(sxModule) {
 		popoverData: {
 			editOperationName: ':contextual-edit-link[@format=dita]',
 			targetIsPermanentId: true,
-			targetQuery: '@href'
+			targetQuery: xq`@href`
 		},
 		showWhen: 'always',
 		blockHeaderLeft: [createMarkupLabelWidget()],
@@ -24,7 +25,7 @@ export default function configureXrefToUsePermanentId(sxModule) {
 	});
 
 	// A web link.
-	configureAsRelatedLink(sxModule, 'self::link[@format="html"]', undefined, {
+	configureAsRelatedLink(sxModule, xq`self::link[@format="html"]`, undefined, {
 		contextualOperations: [{ name: ':link-insert-linktext' }, { name: ':link-insert-desc' }],
 		backgroundColor: 'grey',
 		defaultTextContainer: 'linktext',
@@ -33,7 +34,7 @@ export default function configureXrefToUsePermanentId(sxModule) {
 		popoverData: {
 			editOperationName: ':contextual-edit-link[@format=html]',
 			targetIsPermanentId: true,
-			targetQuery: '@href'
+			targetQuery: xq`@href`
 		},
 		showWhen: 'always',
 		blockHeaderLeft: [createMarkupLabelWidget()],

--- a/packages/dita-example-sx-modules-xsd-topic-mod/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-topic-mod/src/configureSxModule.js
@@ -12,6 +12,7 @@ import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMe
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import createRelatedNodesQueryWidget from 'fontoxml-families/src/createRelatedNodesQueryWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// abstract
@@ -20,7 +21,7 @@ export default function configureSxModule(sxModule) {
 	//     used for providing link previews or summaries. The <abstract> element cannot be overridden by maps,
 	//     but its contained <shortdesc> elements can be, for the purpose of creating link summaries or
 	//     previews. Category: Topic elements
-	configureAsFrame(sxModule, 'self::abstract', t('abstract'), {
+	configureAsFrame(sxModule, xq`self::abstract`, t('abstract'), {
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the summary'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -28,7 +29,7 @@ export default function configureSxModule(sxModule) {
 
 	// body
 	//     The <body> element is the container for the main content of a <topic>. Category: Topic elements
-	configureAsStructure(sxModule, 'self::body', t('body'), {
+	configureAsStructure(sxModule, xq`self::body`, t('body'), {
 		defaultTextContainer: 'p',
 		isRemovableIfEmpty: false
 	});
@@ -40,7 +41,7 @@ export default function configureSxModule(sxModule) {
 	//     should not be contained as a topic. As such, it does not contain an explicit title to avoid enabling
 	//     the creation of deeply nested content that would otherwise be written as separate topics. Content
 	//     that requires a title should use a section element or a nested topic.
-	configureAsFrame(sxModule, 'self::bodydiv', t('body division'), {
+	configureAsFrame(sxModule, xq`self::bodydiv`, t('body division'), {
 		contextualOperations: [{ name: ':contextual-unwrap-bodydiv' }],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the content'),
@@ -52,20 +53,20 @@ export default function configureSxModule(sxModule) {
 	//     The <example> element is a section with the specific role of containing examples that illustrate or
 	//     support the current topic. The <example> element has the same content model as <section>. Category:
 	//     Topic elements
-	configureAsFrame(sxModule, 'self::example', t('example'), {
+	configureAsFrame(sxModule, xq`self::example`, t('example'), {
 		contextualOperations: [
 			{ name: ':example-insert-title' },
 			{ name: ':contextual-unwrap-example' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the content'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// title in example
-	configureAsTitleFrame(sxModule, 'self::title[parent::example]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::example]`, undefined, {
 		fontVariation: 'section-title'
 	});
 
@@ -80,7 +81,7 @@ export default function configureSxModule(sxModule) {
 	//     Links elements
 
 	// A cross link. (cross link is used by default)
-	configureAsRelatedLink(sxModule, 'self::link', t('link'), {
+	configureAsRelatedLink(sxModule, xq`self::link`, t('link'), {
 		contextualOperations: [{ name: ':link-insert-linktext' }, { name: ':link-insert-desc' }],
 		backgroundColor: 'grey',
 		defaultTextContainer: 'linktext',
@@ -88,7 +89,7 @@ export default function configureSxModule(sxModule) {
 		popoverComponentName: 'DitaCrossReferencePopover',
 		popoverData: {
 			editOperationName: ':contextual-edit-link[@format=dita]',
-			targetQuery: '@href'
+			targetQuery: xq`@href`
 		},
 		showWhen: 'always',
 		blockHeaderLeft: [createMarkupLabelWidget()],
@@ -96,7 +97,7 @@ export default function configureSxModule(sxModule) {
 	});
 
 	// A web link.
-	configureAsRelatedLink(sxModule, 'self::link[@format="html"]', undefined, {
+	configureAsRelatedLink(sxModule, xq`self::link[@format="html"]`, undefined, {
 		contextualOperations: [{ name: ':link-insert-linktext' }, { name: ':link-insert-desc' }],
 		backgroundColor: 'grey',
 		defaultTextContainer: 'linktext',
@@ -104,7 +105,7 @@ export default function configureSxModule(sxModule) {
 		popoverComponentName: 'WebReferencePopover',
 		popoverData: {
 			editOperationName: ':contextual-edit-link[@format=html]',
-			targetQuery: '@href'
+			targetQuery: xq`@href`
 		},
 		showWhen: 'always',
 		blockHeaderLeft: [createMarkupLabelWidget()],
@@ -112,33 +113,33 @@ export default function configureSxModule(sxModule) {
 	});
 
 	// desc in link
-	configureAsGroup(sxModule, 'self::desc[parent::link]', undefined, {
+	configureAsGroup(sxModule, xq`self::desc[parent::link]`, undefined, {
 		defaultTextContainer: 'p',
 		blockHeaderLeft: []
 	});
 
 	// p in desc in link
-	configureAsLine(sxModule, 'self::p[parent::desc[parent::link]]', undefined, {
+	configureAsLine(sxModule, xq`self::p[parent::desc[parent::link]]`, undefined, {
 		slant: 'italic'
 	});
 
 	// linkinfo
 	//     The <linkinfo> element allows you to place a descriptive paragraph following a list of links in a
 	//     <linklist> element. Category: Related Links elements
-	configureAsRemoved(sxModule, 'self::linkinfo', t('link information'));
+	configureAsRemoved(sxModule, xq`self::linkinfo`, t('link information'));
 
 	// linklist
 	//     The <linklist> element defines an author-arranged group of links. Within <linklist>, the
 	//     organization of links on final output is in the same order as originally authored in the DITA topic.
 	//     Category: Related Links elements
-	configureAsRemoved(sxModule, 'self::linklist', t('link list'));
+	configureAsRemoved(sxModule, xq`self::linklist`, t('link list'));
 
 	// linkpool
 	//     The <linkpool> element defines a group of links that have common characteristics, such as type or
 	//     audience or source. When links are not in a <linklist> (that is, they are in <related-links> or
 	//     <linkpool> elements), the organization of links on final output is determined by the output process,
 	//     not by the order that the links actually occur in the DITA topic. Category: Related Links elements
-	configureAsRemoved(sxModule, 'self::linkpool', t('link pool'));
+	configureAsRemoved(sxModule, xq`self::linkpool`, t('link pool'));
 
 	// linktext
 	//     The <linktext> element provides the literal label or line of text for a link. In most cases, the
@@ -147,7 +148,7 @@ export default function configureSxModule(sxModule) {
 	//     link, or the target is local but not in DITA format. When used inside a topic, it will be used as
 	//     the text for the specified link; when used within a map, it will be used as the text for generated
 	//     links that point to the specified topic. Category: Related Links elements
-	configureAsLine(sxModule, 'self::linktext', t('linktext'), {
+	configureAsLine(sxModule, xq`self::linktext`, t('linktext'), {
 		emptyElementPlaceholderText: t('type the link text')
 	});
 
@@ -156,21 +157,21 @@ export default function configureSxModule(sxModule) {
 	//     the default DITA document types; it is for use only when creating a validly customized document type
 	//     where the information designer wants to eliminate the ability to nest topics. Not intended for use
 	//     by authors, and has no associated output processing. Category: Specialization elements
-	configureAsRemoved(sxModule, 'self::no-topic-nesting', t('no topic nesting'));
+	configureAsRemoved(sxModule, xq`self::no-topic-nesting`, t('no topic nesting'));
 
 	// prolog
 	//     The <prolog> element contains information about the topic as an whole (for example, author
 	//     information or subject category) that is either entered by the author or machine-maintained. Much of
 	//     the metadata inside the <prolog> will not be displayed with the topic on output, but may be used by
 	//     processes that generate search indexes or customize navigation. Category: Prolog elements
-	configureAsRemoved(sxModule, 'self::prolog', t('metadata'));
+	configureAsRemoved(sxModule, xq`self::prolog`, t('metadata'));
 
 	// related-links
 	//     The related information links of a topic (<related-links> element) are stored in a special section
 	//     following the body of the topic. After a topic is processed into it final output form, the related
 	//     links are usually displayed at the end of the topic, although some Web-based help systems might
 	//     display them in a separate navigation frame. Category: Topic elements
-	configureAsOutOfOrderStructure(sxModule, 'self::related-links', t('related links'), {
+	configureAsOutOfOrderStructure(sxModule, xq`self::related-links`, t('related links'), {
 		expression: 'compact',
 		isAutoremovableIfEmpty: true,
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -182,7 +183,7 @@ export default function configureSxModule(sxModule) {
 	//     summaries by some search engines, such as that in Eclipse (http://eclipse.org); if not set, the
 	//     XHTML's title element defaults to the source topic's title content (which may not be as well
 	//     optimized for search summaries) Category: Topic elements
-	configureAsFrameWithBlock(sxModule, 'self::searchtitle', t('search title'), {
+	configureAsFrameWithBlock(sxModule, xq`self::searchtitle`, t('search title'), {
 		emptyElementPlaceholderText: t('type the search title'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -195,20 +196,20 @@ export default function configureSxModule(sxModule) {
 	//     topic. Multiple sections within a single topic do not represent a hierarchy, but rather peer
 	//     divisions of that topic. Sections cannot be nested. A section may have an optional title. Category:
 	//     Topic elements
-	configureAsFrame(sxModule, 'self::section', t('section'), {
+	configureAsFrame(sxModule, xq`self::section`, t('section'), {
 		contextualOperations: [
 			{ name: ':section-insert-title' },
 			{ name: ':contextual-unwrap-section' }
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the content'),
-		titleQuery: './title',
+		titleQuery: xq`./title`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()]
 	});
 
 	// title in section
-	configureAsTitleFrame(sxModule, 'self::title[parent::section]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::section]`, undefined, {
 		fontVariation: 'section-title'
 	});
 
@@ -218,7 +219,7 @@ export default function configureSxModule(sxModule) {
 	//     content. The sectiondiv element does not contain a title; the lowest level of titled content within
 	//     a topic is the section itself. If additional hierarchy is required, nested topics should be used in
 	//     place of the section.
-	configureAsFrame(sxModule, 'self::sectiondiv', t('section division'), {
+	configureAsFrame(sxModule, xq`self::sectiondiv`, t('section division'), {
 		contextualOperations: [{ name: ':contextual-unwrap-sectiondiv' }],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('type the content'),
@@ -232,7 +233,7 @@ export default function configureSxModule(sxModule) {
 	//     short description, which represents the purpose or theme of the topic, is also intended to be used
 	//     as a link preview and for searching. When used within a DITA map, the short description of the
 	//     <topicref> can be used to override the short description in the topic. Category: Topic elements
-	configureAsFrameWithBlock(sxModule, 'self::shortdesc', t('short description'), {
+	configureAsFrameWithBlock(sxModule, xq`self::shortdesc`, t('short description'), {
 		emptyElementPlaceholderText: t('type the short description'),
 		blockHeaderLeft: [createMarkupLabelWidget()]
 	});
@@ -241,7 +242,7 @@ export default function configureSxModule(sxModule) {
 	//     The alternate title element (<titlealts>) is optional, but can occur after the topic title. Two
 	//     elements can be inserted as sub-elements of <titlealts>: navigation title <navtitle> and search
 	//     title <searchtitle>. Category: Topic elements
-	configureAsStructure(sxModule, 'self::titlealts', t('alternate titles'), {
+	configureAsStructure(sxModule, xq`self::titlealts`, t('alternate titles'), {
 		isAutoremovableIfEmpty: true
 	});
 
@@ -249,14 +250,14 @@ export default function configureSxModule(sxModule) {
 	//     The <topic> element is the top-level DITA element for a single-subject topic or article. Other
 	//     top-level DITA elements that are more content-specific are <concept>, <task>, <reference>, and
 	//     <glossary>. Category: Topic elements
-	configureAsSheetFrame(sxModule, 'self::topic', t('topic'), {
+	configureAsSheetFrame(sxModule, xq`self::topic`, t('topic'), {
 		defaultTextContainer: 'body',
 		titleQuery:
-			'./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()',
+			xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
 		blockFooter: [
-			createRelatedNodesQueryWidget('./related-links'),
+			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(
-				'descendant::fn[not(@conref) and fonto:in-inline-layout(.)]'
+				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`
 			)
 		],
 		blockHeaderLeft: [createMarkupLabelWidget()]
@@ -265,17 +266,17 @@ export default function configureSxModule(sxModule) {
 	// topic nested in topic
 	configureAsFrame(
 		sxModule,
-		'self::topic[parent::*[fonto:dita-class(., "topic/topic")]]',
+		xq`self::topic[parent::*[fonto:dita-class(., "topic/topic")]]`,
 		undefined,
 		{
 			defaultTextContainer: 'body',
-			blockFooter: [createRelatedNodesQueryWidget('./related-links')],
+			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()]
 		}
 	);
 
 	// title in topic
-	configureAsTitleFrame(sxModule, 'self::title[parent::topic]', undefined, {
+	configureAsTitleFrame(sxModule, xq`self::title[parent::topic]`, undefined, {
 		fontVariation: 'document-title'
 	});
 }

--- a/packages/dita-example-sx-modules-xsd-ui-domain/src/configureSxModule.js
+++ b/packages/dita-example-sx-modules-xsd-ui-domain/src/configureSxModule.js
@@ -5,6 +5,7 @@ import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMe
 import createIconWidget from 'fontoxml-families/src/createIconWidget.js';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// menucascade
@@ -14,7 +15,7 @@ export default function configureSxModule(sxModule) {
 	//     characters between the menu items to represent the menu cascade. This element is part of the DITA
 	//     user interface domain, a special set of DITA elements designed to document user interface tasks,
 	//     concepts and reference information. Category: User interface elements
-	configureAsInlineFrame(sxModule, 'self::menucascade', t('menu cascade'), {
+	configureAsInlineFrame(sxModule, xq`self::menucascade`, t('menu cascade'), {
 		defaultTextContainer: {
 			localName: 'uicontrol',
 			namespaceURI: null,
@@ -27,7 +28,7 @@ export default function configureSxModule(sxModule) {
 	// screen
 	//     The <screen> element contains or refers to a textual representation of a computer screen or user
 	//     interface panel (window). Category: User interface elements
-	configureAsFrameWithBreakableBlock(sxModule, 'self::screen', t('screen'), {
+	configureAsFrameWithBreakableBlock(sxModule, xq`self::screen`, t('screen'), {
 		backgroundColor: 'brown',
 		contextualOperations: [{ name: ':contextual-unwrap-screen' }],
 		emptyElementPlaceholderText: t('type the screen text'),
@@ -42,7 +43,7 @@ export default function configureSxModule(sxModule) {
 	//     The <shortcut> element identifies a keyboard shortcut for a menu or window action. This element is
 	//     part of the DITA user interface domain, a special set of DITA elements designed to document user
 	//     interface tasks, concepts and reference information. Category: User interface elements
-	configureAsInlineFrame(sxModule, 'self::shortcut', t('shortcut'), {
+	configureAsInlineFrame(sxModule, xq`self::shortcut`, t('shortcut'), {
 		emptyElementPlaceholderText: t('type the shortcut')
 	});
 
@@ -53,13 +54,13 @@ export default function configureSxModule(sxModule) {
 	//     as File New. This element is part of the DITA user interface domain, a special set of DITA elements
 	//     designed to document user interface tasks, concepts and reference information. Category: User
 	//     interface elements
-	configureAsInlineFrame(sxModule, 'self::uicontrol', t('UI control'), {
+	configureAsInlineFrame(sxModule, xq`self::uicontrol`, t('UI control'), {
 		emptyElementPlaceholderText: t('type the label of the UI control')
 	});
 
 	configureProperties(
 		sxModule,
-		'self::uicontrol[parent::menucascade and preceding-sibling::uicontrol]',
+		xq`self::uicontrol[parent::menucascade and preceding-sibling::uicontrol]`,
 		{
 			emptyElementPlaceholderText: t('type the label of the UI control'),
 			inlineBefore: [createIconWidget('angle-right')]
@@ -72,7 +73,7 @@ export default function configureSxModule(sxModule) {
 	//     and window pane titles. This element is part of the DITA user interface domain, a special set of
 	//     DITA elements designed to document user interface tasks, concepts and reference information.
 	//     Category: User interface elements
-	configureAsInlineFrame(sxModule, 'self::wintitle', t('window title'), {
+	configureAsInlineFrame(sxModule, xq`self::wintitle`, t('window title'), {
 		emptyElementPlaceholderText: t('type the window title')
 	});
 }

--- a/packages/dita-example-sx-pivot-model-translation/src/configureSxModule.js
+++ b/packages/dita-example-sx-pivot-model-translation/src/configureSxModule.js
@@ -1,4 +1,5 @@
 import pivotModelTransformerManager from 'fontoxml-pivot-model/src/pivotModelTransformerManager.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
 	// This is the configuration for transforming clipboard data, for example from MS Word or your browser, into
@@ -100,7 +101,7 @@ export default function configureSxModule(sxModule) {
 	]);
 
 	// Ignore blocks under <pre>
-	pivotModelTransformerManager.registerContextualTransformer(sxModule, 'ancestor-or-self::pre', {
+	pivotModelTransformerManager.registerContextualTransformer(sxModule, xq`ancestor-or-self::pre`, {
 		qualifiedName: null,
 		type: 'block'
 	});

--- a/packages/dita-example-sx-shells-general-task/src/configureSxModule.js
+++ b/packages/dita-example-sx-shells-general-task/src/configureSxModule.js
@@ -1,6 +1,7 @@
 import configureMarkupLabel from 'fontoxml-families/src/configureMarkupLabel.js';
 import t from 'fontoxml-localization/src/t.js';
+import xq from 'fontoxml-selectors/src/xq';
 
 export default function configureSxModule(sxModule) {
-	configureMarkupLabel(sxModule, 'self::task', t('general task'));
+	configureMarkupLabel(sxModule, xq`self::task`, t('general task'));
 }


### PR DESCRIPTION
Hello @EvadeHaas and @brocelot! 

We have rewritten this editor to use xquery template tags, as a way to promote it to partners since this editor is often used as reference.

Could you review the changes by checking the code and testing the editor functionality? It might be that some elements did break while implementing the xq function, but do not cause the editor to crash.

Some notes:
1) The MathML functions have not been converted. The code for this is done and has been integrated into platform, but will only release with 7.18. As this repo is public, it should be compatible with the latest public version.
2) The createLabelQueryWidget function in platform still needs to be updated to work with xq.
3) All other functions should work and have the xq prefix.  If you find any xqueries that are not preceded by the xq function, we simply missed them. Please report any you come across.
