### PR TITLE
DEV-16192 Change old way of getting the title query to the new `curated-text-in-node`

### DIFF
--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-assessment-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-assessment-mod/src/configureSxModule.ts
@@ -21,7 +21,7 @@ export default function configureSxModule(sxModule: SxModule) {
 		t('learning assessment'),
 		{
 			defaultTextContainer: 'learningAssessmentbody',
-			titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+			titleQuery: xq`fonto:curated-text-in-node(./title)`,
 			blockFooter: [
 				createRelatedNodesQueryWidget(xq`./related-links`),
 				createRelatedNodesQueryWidget(

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-content-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-content-mod/src/configureSxModule.ts
@@ -22,7 +22,7 @@ export default function configureSxModule(sxModule: SxModule) {
 		t('learning content'),
 		{
 			defaultTextContainer: 'learningContentbody',
-			titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+			titleQuery: xq`fonto:curated-text-in-node(./title)`,
 			blockFooter: [
 				createRelatedNodesQueryWidget(xq`./related-links`),
 				createRelatedNodesQueryWidget(

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-overview-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-overview-mod/src/configureSxModule.ts
@@ -20,7 +20,7 @@ export default function configureSxModule(sxModule: SxModule) {
 		t('learning overview'),
 		{
 			defaultTextContainer: 'learningOverviewbody',
-			titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+			titleQuery: xq`fonto:curated-text-in-node(./title)`,
 			blockFooter: [
 				createRelatedNodesQueryWidget(xq`./related-links`),
 				createRelatedNodesQueryWidget(
@@ -38,7 +38,7 @@ export default function configureSxModule(sxModule: SxModule) {
 		undefined,
 		{
 			defaultTextContainer: 'learningOverviewbody',
-			titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+			titleQuery: xq`fonto:curated-text-in-node(./title)`,
 			blockFooter: [createRelatedNodesQueryWidget(xq`./related-links`)],
 			blockHeaderLeft: [createMarkupLabelWidget()],
 		}

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.ts
@@ -824,7 +824,7 @@ export default function configureSxModule(sxModule: SxModule) {
 		t('learning plan'),
 		{
 			defaultTextContainer: 'learningPlanbody',
-			titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+			titleQuery: xq`fonto:curated-text-in-node(./title)`,
 			blockFooter: [
 				createRelatedNodesQueryWidget(xq`./related-links`),
 				createRelatedNodesQueryWidget(

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-summary-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-summary-mod/src/configureSxModule.ts
@@ -20,7 +20,7 @@ export default function configureSxModule(sxModule: SxModule) {
 		t('learning summary'),
 		{
 			defaultTextContainer: 'learningSummarybody',
-			titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+			titleQuery: xq`fonto:curated-text-in-node(./title)`,
 			blockFooter: [
 				createRelatedNodesQueryWidget(xq`./related-links`),
 				createRelatedNodesQueryWidget(

--- a/packages/dita-example-sx-modules-xsd-concept-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-concept-mod/src/configureSxModule.ts
@@ -63,7 +63,7 @@ export default function configureSxModule(sxModule: SxModule) {
 	//     concept is fairly simple. Category: Concept elements
 	configureAsSheetFrame(sxModule, xq`self::concept`, t('concept'), {
 		defaultTextContainer: 'conbody',
-		titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+		titleQuery: xq`fonto:curated-text-in-node(./title)`,
 		blockFooter: [
 			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(

--- a/packages/dita-example-sx-modules-xsd-glossgroup-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-glossgroup-mod/src/configureSxModule.ts
@@ -12,7 +12,7 @@ export default function configureSxModule(sxModule: SxModule) {
 	//     The <glossgroup> element may be used to contain multiple <glossentry> topics within a single
 	//     collection.
 	configureAsSheetFrame(sxModule, xq`self::glossgroup`, t('glossary'), {
-		titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+		titleQuery: xq`fonto:curated-text-in-node(./title)`,
 		blockFooter: [
 			createRelatedNodesQueryWidget(
 				xq`descendant::fn[not(@conref) and fonto:in-inline-layout(.)]`

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.ts
@@ -273,7 +273,7 @@ export default function configureSxModule(sxModule: SxModule) {
 	//     elements
 	configureAsSheetFrame(sxModule, xq`self::reference`, t('reference'), {
 		defaultTextContainer: 'refbody',
-		titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+		titleQuery: xq`fonto:curated-text-in-node(./title)`,
 		blockFooter: [
 			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(

--- a/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.ts
@@ -492,7 +492,7 @@ export default function configureSxModule(sxModule: SxModule) {
 	//     with a title, short description and body. Category: Task elements
 	configureAsSheetFrame(sxModule, xq`self::task`, t('task'), {
 		defaultTextContainer: 'taskbody',
-		titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+		titleQuery: xq`fonto:curated-text-in-node(./title)`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockFooter: [
 			createRelatedNodesQueryWidget(xq`./related-links`),

--- a/packages/dita-example-sx-modules-xsd-topic-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-topic-mod/src/configureSxModule.ts
@@ -298,7 +298,7 @@ export default function configureSxModule(sxModule: SxModule) {
 	//     <glossary>. Category: Topic elements
 	configureAsSheetFrame(sxModule, xq`self::topic`, t('topic'), {
 		defaultTextContainer: 'body',
-		titleQuery: xq`./title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+		titleQuery: xq`fonto:curated-text-in-node(./title)`,
 		blockFooter: [
 			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(


### PR DESCRIPTION
 This commit includes fixes for the use of the TitleQuery `xq` parameter.
`fonto:curated-text-in-node(./title)`