### PR TITLE
Tweaks to declarative loading strategy configuration

### DIFF
--- a/packages/dita-example-sx-hierarchy/src/configureSxModule.ts
+++ b/packages/dita-example-sx-hierarchy/src/configureSxModule.ts
@@ -69,4 +69,13 @@ export default function configureSxModule(sxModule: SxModule): void {
 			hierarchyChildNodesQuery: xq`(child::*[fonto:dita-class(., "map/topicref")], fonto:document(@href)/*/fonto:hierarchy-child-nodes(.))`,
 		}
 	);
+
+	// Maprefs don't need the format attribute and always refer to DITA maps
+	configureProperties(sxModule, xq`self::mapref`, {
+		// This needs priority as the fonto:dita-class selectors in the rules above are considered
+		// to be more specific than self::mapref and would otherwise take precedence.
+		priority: 10,
+		// Combine children of the topicref with the hierarchy children of the target map
+		hierarchyChildNodesQuery: xq`(child::*[fonto:dita-class(., "map/topicref")], fonto:document(@href)/*/fonto:hierarchy-child-nodes(.))`,
+	});
 }

--- a/packages/dita-example-sx-hierarchy/src/configureSxModule.ts
+++ b/packages/dita-example-sx-hierarchy/src/configureSxModule.ts
@@ -24,19 +24,11 @@ import xq from 'fontoxml-selectors/src/xq';
  * intended interpretation of specific elements.
  */
 export default function configureSxModule(sxModule: SxModule): void {
-	// Any root-level document has a hierarchy node for its root element
-	configureProperties(sxModule, xq`self::document-node()`, {
-		hierarchyChildNodesQuery: xq`child::*`,
-		hierarchyContentQuery: null,
-	});
-
 	// Configure map and its specializations
 
 	configureProperties(sxModule, xq`self::*[fonto:dita-class(., "map/map")]`, {
 		// maps have topicrefs and any of its specializations as children
 		hierarchyChildNodesQuery: xq`child::*[fonto:dita-class(., "map/topicref")]`,
-		// maps show a sheetframe for themselves
-		hierarchyContentQuery: xq`.`,
 	});
 
 	// Configure topicref and its specializations
@@ -49,12 +41,14 @@ export default function configureSxModule(sxModule: SxModule): void {
 			hierarchyChildNodesQuery: xq`child::*[fonto:dita-class(., "map/topicref")]`,
 		}
 	);
-	// Each topicref with an href points at a content document
+	// Each topicref with an href points at a content document. We'll use the document element for
+	// consistency and to provide a useful `contextNodeId` on operations triggered from the
+	// hierarchy node's Outline item.
 	configureProperties(
 		sxModule,
 		xq`self::*[fonto:dita-class(., "map/topicref") and @href]`,
 		{
-			hierarchyContentQuery: xq`fonto:document(@href)`,
+			hierarchyContentQuery: xq`fonto:document(@href)/*`,
 		}
 	);
 	// Each topicref without an href represents itself (e.g., topichead / topicgroup)

--- a/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.ts
@@ -2,7 +2,6 @@ import configureAsRemoved from 'fontoxml-families/src/configureAsRemoved';
 import configureAsSheetFrame from 'fontoxml-families/src/configureAsSheetFrame';
 import configureAsStructure from 'fontoxml-families/src/configureAsStructure';
 import configureAsTitleFrame from 'fontoxml-families/src/configureAsTitleFrame';
-import configureProperties from 'fontoxml-families/src/configureProperties';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget';
 import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
@@ -29,15 +28,6 @@ export default function configureSxModule(sxModule: SxModule) {
 	//     into the container map at the position of the reference, and the relationship tables of the child
 	//     map are added to the parent map.
 	configureAsRemoved(sxModule, xq`self::mapref`, t('mapref'));
-
-	// Override hierarchy config as maprefs don't need the format attribute and always refer to DITA maps
-	configureProperties(sxModule, xq`self::mapref`, {
-		// This needs priority as the fonto:dita-class selectors in dita-example-sx-hierarchy are
-		// considered to be more specific than self::mapref and would otherwise take precedence.
-		priority: 10,
-		// Combine children of the topicref with the hierarchy children of the target map
-		hierarchyChildNodesQuery: xq`(child::*[fonto:dita-class(., "map/topicref")], fonto:document(@href)/*/fonto:hierarchy-child-nodes(.))`,
-	});
 
 	// topichead
 	//     The <topichead> element provides a title-only entry in a navigation map, as an alternative to the


### PR DESCRIPTION
This updates the configuration (still on its own feature branch) to match the new platform defaults, and simplifies its reuse by moving the mapref rule into the same package as the rest of the configuration.