### PR TITLE
DEV-18991 Update linter configuration and fix errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,12 +4,11 @@ module.exports = {
 	},
 	extends: ['@fontoxml', '@fontoxml/eslint-config/typeinfo'],
 	ignorePatterns: [
-		'editor/config.json',
 		'.eslintrc.js',
-		'editor/dev-cms/**',
-		'editor/packages/*/assets/**',
-		'editor/platform/**',
-		'schema/**',
+		'config.json',
+		'dev-cms/**',
+		'packages/*/assets/**',
+		'platform/**',
 	],
 	parserOptions: {
 		// Required for running TypeScript/type-aware rules.

--- a/package.json
+++ b/package.json
@@ -6,25 +6,25 @@
 	"scripts": {
 		"start": "fdt editor run",
 		"postinstall": "fdt editor upgrade --non-interactive --version 8.5.2",
-		"lint": "eslint \"./packages/**/*.ts\" \"./packages/**/*.tsx\" \"./config/**/*.ts\"",
-		"lint-fix": "eslint --fix \"./packages/**/*.ts\" \"./packages/**/*.tsx\" \"./config/**/*.ts\""
+		"lint": "eslint \"./packages/**/*.ts\" \"./packages/**/*.tsx\" \"./config/**/*.ts\""
 	},
 	"devDependencies": {
 		"@babel/eslint-plugin": "7.14.5",
-		"@fontoxml/eslint-config": "4.0.2",
+		"@fontoxml/eslint-config": "4.1.1",
 		"@types/chai": "4.2.19",
 		"@types/mocha": "8.2.2",
 		"@types/sinon": "10.0.2",
 		"@typescript-eslint/eslint-plugin": "4.28.0",
-		"eslint": "^7.29.0",
+		"eslint": "7.29.0",
 		"eslint-config-prettier": "8.3.0",
 		"eslint-import-resolver-typescript": "2.4.0",
 		"eslint-plugin-import": "2.23.4",
 		"eslint-plugin-prettier": "3.4.0",
-		"eslint-plugin-react": "7.24.0",
-		"eslint-plugin-react-hooks": "4.2.0",
+		"eslint-plugin-react": "7.32.2",
+		"eslint-plugin-react-hooks": "4.6.0",
 		"eslint-plugin-simple-import-sort": "7.0.0",
 		"prettier": "2.3.2",
-		"typescript": "4.3.4"
+		"typescript": "4.3.4",
+		"typescript-strict-plugin": "2.1.0"
 	}
 }

--- a/packages/dita-example-masthead/src/DitaExampleMasthead.tsx
+++ b/packages/dita-example-masthead/src/DitaExampleMasthead.tsx
@@ -1,6 +1,7 @@
-import { Flex } from 'fds/components';
-import React, { useMemo } from 'react';
+import type { FC } from 'react';
+import { useMemo } from 'react';
 
+import { Flex } from 'fontoxml-design-system/src/components';
 import FindAndReplaceDropButton from 'fontoxml-find-and-replace/src/FindAndReplaceDropButton';
 import FxEditorMasthead from 'fontoxml-fx/src/FxEditorMasthead';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
@@ -80,7 +81,7 @@ const tabs = (result) => [
 	{ id: 'tools', label: 'Tools', content: <ToolsToolbar /> },
 ];
 
-export default function DitaExampleMasthead() {
+const DitaExampleMasthead: FC = () => {
 	const matching = useXPath(
 		xq`fonto:selection-common-ancestor()/ancestor-or-self::lcMatching2`,
 		null,
@@ -162,4 +163,6 @@ export default function DitaExampleMasthead() {
 			tabs={tabs(xpathQueryResultByName)}
 		/>
 	);
-}
+};
+
+export default DitaExampleMasthead;

--- a/packages/dita-example-masthead/src/install.ts
+++ b/packages/dita-example-masthead/src/install.ts
@@ -2,6 +2,6 @@ import uiManager from 'fontoxml-modular-ui/src/uiManager';
 
 import DitaExampleMasthead from './DitaExampleMasthead';
 
-export default function install() {
+export default function install(): void {
 	uiManager.registerReactComponent('Masthead', DitaExampleMasthead);
 }

--- a/packages/dita-example-masthead/src/menus/InsertTopicMenu.tsx
+++ b/packages/dita-example-masthead/src/menus/InsertTopicMenu.tsx
@@ -1,9 +1,14 @@
 import bookmapElementLabels from 'dita-example-sx-modules-xsd-bookmap-mod/src/api/bookmapElementLabels';
-import { Drop, Menu, MenuGroup, MenuItemWithDrop } from 'fds/components';
-import * as React from 'react';
+import type { FC } from 'react';
 import { useEffect, useState } from 'react';
 
 import readOnlyBlueprint from 'fontoxml-blueprints/src/readOnlyBlueprint';
+import {
+	Drop,
+	Menu,
+	MenuGroup,
+	MenuItemWithDrop,
+} from 'fontoxml-design-system/src/components';
 import documentsHierarchy from 'fontoxml-documents/src/documentsHierarchy';
 import documentsManager from 'fontoxml-documents/src/documentsManager';
 import getNodeId from 'fontoxml-dom-identification/src/getNodeId';
@@ -169,7 +174,7 @@ function createTopicSubMenu(refNodeId) {
 	);
 }
 
-const InsertTopicMenu = () => {
+const InsertTopicMenu: FC = () => {
 	const selectionNode = useXPath(
 		xq`fonto:selection-common-ancestor()`,
 		null,
@@ -327,6 +332,7 @@ const InsertTopicMenu = () => {
 	if (refElementName === 'bookmap') {
 		return wrapInMenu([
 			<FxOperationMenuItem
+				key=":contextual-insert-frontmatter"
 				operationName=":contextual-insert-frontmatter"
 				operationData={{ contextNodeId: refNodeId }}
 			/>,
@@ -359,6 +365,7 @@ const InsertTopicMenu = () => {
 				)}
 			</>,
 			<FxOperationMenuItem
+				key=":contextual-insert-backmatter"
 				operationName=":contextual-insert-backmatter"
 				operationData={{ contextNodeId: refNodeId }}
 			/>,

--- a/packages/dita-example-masthead/src/toolbars/AdvancedToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/AdvancedToolbar.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import {
 	ButtonWithDrop,
 	Drop,
@@ -5,125 +7,125 @@ import {
 	MastheadToolbarButtons,
 	Menu,
 	MenuGroup,
-} from 'fds/components';
-import * as React from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 import FxOperationMenuItem from 'fontoxml-fx/src/FxOperationMenuItem';
 
-const AdvancedToolbar = () => (
-	<MastheadToolbar>
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				label="Alternate title"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<FxOperationMenuItem operationName=":insert-navtitle" />
-							<FxOperationMenuItem operationName=":insert-searchtitle" />
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
+const AdvancedToolbar: FC = () => {
+	return (
+		<MastheadToolbar>
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					label="Alternate title"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<FxOperationMenuItem operationName=":insert-navtitle" />
+								<FxOperationMenuItem operationName=":insert-searchtitle" />
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":insert-term" />
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":insert-term" />
 
-			<FxOperationButton operationName=":insert-keyword" />
-		</MastheadToolbarButtons>
+				<FxOperationButton operationName=":insert-keyword" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				icon="exclamation-circle"
-				label="Hazard statement"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-hazardstatement" />
-							</MenuGroup>
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					icon="exclamation-circle"
+					label="Hazard statement"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-hazardstatement" />
+								</MenuGroup>
 
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=attention]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=caution]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=danger]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=fastpath]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=important]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=notice]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=remember]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=restriction]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=tip]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=warning]" />
-								<FxOperationMenuItem operationName=":insert-hazardstatement[@type=other]" />
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=attention]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=caution]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=danger]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=fastpath]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=important]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=notice]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=remember]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=restriction]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=tip]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=warning]" />
+									<FxOperationMenuItem operationName=":insert-hazardstatement[@type=other]" />
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				label="Reference"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<FxOperationMenuItem operationName=":insert-refsyn" />
-							<FxOperationMenuItem operationName=":insert-properties" />
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					label="Reference"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<FxOperationMenuItem operationName=":insert-refsyn" />
+								<FxOperationMenuItem operationName=":insert-properties" />
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				label="User interface"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-screen" />
-							</MenuGroup>
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					label="User interface"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-screen" />
+								</MenuGroup>
 
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":toggle-wintitle" />
-								<FxOperationMenuItem operationName=":toggle-shortcut" />
-							</MenuGroup>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":toggle-wintitle" />
+									<FxOperationMenuItem operationName=":toggle-shortcut" />
+								</MenuGroup>
 
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-menucascade" />
-								<FxOperationMenuItem operationName=":insert-uicontrol" />
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-menucascade" />
+									<FxOperationMenuItem operationName=":insert-uicontrol" />
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
 
-			<ButtonWithDrop
-				label="Programming"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-codeblock" />
-								<FxOperationMenuItem operationName=":insert-parml" />
-							</MenuGroup>
+				<ButtonWithDrop
+					label="Programming"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-codeblock" />
+									<FxOperationMenuItem operationName=":insert-parml" />
+								</MenuGroup>
 
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":toggle-apiname" />
-								<FxOperationMenuItem operationName=":toggle-codeph" />
-								<FxOperationMenuItem operationName=":toggle-option" />
-								<FxOperationMenuItem operationName=":toggle-parmname" />
-								<FxOperationMenuItem operationName=":toggle-synph" />
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
-	</MastheadToolbar>
-);
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":toggle-apiname" />
+									<FxOperationMenuItem operationName=":toggle-codeph" />
+									<FxOperationMenuItem operationName=":toggle-option" />
+									<FxOperationMenuItem operationName=":toggle-parmname" />
+									<FxOperationMenuItem operationName=":toggle-synph" />
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
+		</MastheadToolbar>
+	);
+};
 
 export default AdvancedToolbar;

--- a/packages/dita-example-masthead/src/toolbars/GlossaryToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/GlossaryToolbar.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import {
 	ButtonWithDrop,
 	Drop,
@@ -5,48 +7,48 @@ import {
 	MastheadToolbarButtons,
 	Menu,
 	MenuGroup,
-} from 'fds/components';
-import * as React from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 import FxOperationMenuItem from 'fontoxml-fx/src/FxOperationMenuItem';
 
-const GlossaryToolbar = () => (
-	<MastheadToolbar>
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":insert-glossentry" />
+const GlossaryToolbar: FC = () => {
+	return (
+		<MastheadToolbar>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":insert-glossentry" />
 
-			<FxOperationButton
-				label="Sort entries"
-				operationName="glossentry-sort"
-				tooltipContent="Sorts the entries in this group alphabetically by term."
-			/>
-		</MastheadToolbarButtons>
+				<FxOperationButton
+					label="Sort entries"
+					operationName="glossentry-sort"
+					tooltipContent="Sorts the entries in this group alphabetically by term."
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":insert-glossdef" />
-			<FxOperationButton operationName=":insert-glossUsage--in-glossentry" />
-			<ButtonWithDrop
-				label="Variation"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-glossAbbreviation" />
-								<FxOperationMenuItem operationName=":insert-glossAcronym" />
-								<FxOperationMenuItem operationName=":insert-glossShortForm" />
-								<FxOperationMenuItem operationName=":insert-glossSynonym" />
-							</MenuGroup>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":insert-glossdef" />
+				<FxOperationButton operationName=":insert-glossUsage--in-glossentry" />
+				<ButtonWithDrop
+					label="Variation"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-glossAbbreviation" />
+									<FxOperationMenuItem operationName=":insert-glossAcronym" />
+									<FxOperationMenuItem operationName=":insert-glossShortForm" />
+									<FxOperationMenuItem operationName=":insert-glossSynonym" />
+								</MenuGroup>
 
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-glossUsage--in-glossAlt" />
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
-	</MastheadToolbar>
-);
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-glossUsage--in-glossAlt" />
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
+		</MastheadToolbar>
+	);
+};
 
 export default GlossaryToolbar;

--- a/packages/dita-example-masthead/src/toolbars/InlineToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/InlineToolbar.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import {
 	ButtonWithDrop,
 	Drop,
@@ -5,101 +7,101 @@ import {
 	MastheadToolbarButtons,
 	Menu,
 	MenuGroup,
-} from 'fds/components';
-import * as React from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 import FxOperationMenuItem from 'fontoxml-fx/src/FxOperationMenuItem';
 import FxOperationsSplitButtonWithDropMenu from 'fontoxml-fx/src/FxOperationsSplitButtonWithDropMenu';
 
-const InlineToolbar = () => (
-	<MastheadToolbar>
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				label="Formatting"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":toggle-b" />
-								<FxOperationMenuItem operationName=":toggle-i" />
-								<FxOperationMenuItem operationName=":toggle-u" />
-								<FxOperationMenuItem operationName=":toggle-line-through" />
-							</MenuGroup>
+const InlineToolbar: FC = () => {
+	return (
+		<MastheadToolbar>
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					label="Formatting"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":toggle-b" />
+									<FxOperationMenuItem operationName=":toggle-i" />
+									<FxOperationMenuItem operationName=":toggle-u" />
+									<FxOperationMenuItem operationName=":toggle-line-through" />
+								</MenuGroup>
 
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":toggle-overline" />
-								<FxOperationMenuItem operationName=":toggle-tt" />
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":toggle-overline" />
+									<FxOperationMenuItem operationName=":toggle-tt" />
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":toggle-sub" />
-			<FxOperationButton operationName=":toggle-sup" />
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":toggle-sub" />
+				<FxOperationButton operationName=":toggle-sup" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":toggle-ph" />
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":toggle-ph" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":toggle-q" />
-			<ButtonWithDrop
-				icon="trademark"
-				label="Trademark"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-tm[@tmtype=reg]" />
-							</MenuGroup>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":toggle-q" />
+				<ButtonWithDrop
+					icon="trademark"
+					label="Trademark"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-tm[@tmtype=reg]" />
+								</MenuGroup>
 
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-tm[@tmtype=tm]" />
-								<FxOperationMenuItem operationName=":insert-tm[@tmtype=service]" />
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-tm[@tmtype=tm]" />
+									<FxOperationMenuItem operationName=":insert-tm[@tmtype=service]" />
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				icon="link"
-				label="Link"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<FxOperationMenuItem operationName=":insert-xref[@format=html]" />
-							<FxOperationMenuItem operationName=":insert-xref[@format=dita]" />
-						</Menu>
-					</Drop>
-				)}
-			/>
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					icon="link"
+					label="Link"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<FxOperationMenuItem operationName=":insert-xref[@format=html]" />
+								<FxOperationMenuItem operationName=":insert-xref[@format=dita]" />
+							</Menu>
+						</Drop>
+					)}
+				/>
 
-			<FxOperationsSplitButtonWithDropMenu
-				operations={[
-					{ operationName: ':insert-image' },
-					{ operationName: ':insert-fig.image' },
-				]}
-				tooltipContent="Any of the below"
-			/>
+				<FxOperationsSplitButtonWithDropMenu
+					operations={[
+						{ operationName: ':insert-image' },
+						{ operationName: ':insert-fig.image' },
+					]}
+					tooltipContent="Any of the below"
+				/>
 
-			<FxOperationsSplitButtonWithDropMenu
-				operations={[
-					{ operationName: ':insert-equation-inline' },
-					{ operationName: ':insert-equation-figure' },
-					{ operationName: ':insert-equation-block' },
-				]}
-				tooltipContent="Any of the below"
-			/>
-		</MastheadToolbarButtons>
-	</MastheadToolbar>
-);
+				<FxOperationsSplitButtonWithDropMenu
+					operations={[
+						{ operationName: ':insert-equation-inline' },
+						{ operationName: ':insert-equation-figure' },
+						{ operationName: ':insert-equation-block' },
+					]}
+					tooltipContent="Any of the below"
+				/>
+			</MastheadToolbarButtons>
+		</MastheadToolbar>
+	);
+};
 
 export default InlineToolbar;

--- a/packages/dita-example-masthead/src/toolbars/LearningAssessmentToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/LearningAssessmentToolbar.tsx
@@ -1,28 +1,33 @@
-import { MastheadToolbar, MastheadToolbarButtons } from 'fds/components';
-import * as React from 'react';
+import type { FC } from 'react';
 
+import {
+	MastheadToolbar,
+	MastheadToolbarButtons,
+} from 'fontoxml-design-system/src/components';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 
-const LearningAssessmentToolbar = () => (
-	<MastheadToolbar>
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":insert-lcIntro" />
-			<FxOperationButton operationName=":insert-lcObjectives" />
-			<FxOperationButton operationName=":insert-lcDuration" />
-		</MastheadToolbarButtons>
+const LearningAssessmentToolbar: FC = () => {
+	return (
+		<MastheadToolbar>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":insert-lcIntro" />
+				<FxOperationButton operationName=":insert-lcObjectives" />
+				<FxOperationButton operationName=":insert-lcDuration" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":insert-lcSummary" />
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":insert-lcSummary" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":insert-lcInstructornote2" />
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":insert-lcInstructornote2" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName="insert-{question}--from-operation-browser" />
-		</MastheadToolbarButtons>
-	</MastheadToolbar>
-);
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName="insert-{question}--from-operation-browser" />
+			</MastheadToolbarButtons>
+		</MastheadToolbar>
+	);
+};
 
 export default LearningAssessmentToolbar;

--- a/packages/dita-example-masthead/src/toolbars/LearningTrainingToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/LearningTrainingToolbar.tsx
@@ -1,3 +1,6 @@
+import type { FC } from 'react';
+import { useMemo } from 'react';
+
 import {
 	ButtonWithDrop,
 	Drop,
@@ -6,9 +9,7 @@ import {
 	Menu,
 	MenuGroup,
 	MenuItemWithDrop,
-} from 'fds/components';
-import React, { useMemo } from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 import FxOperationMenuItem from 'fontoxml-fx/src/FxOperationMenuItem';
 import useXPath from 'fontoxml-fx/src/useXPath';
@@ -109,7 +110,7 @@ const renderNeedsAnalysisDrop = () => (
 	</Drop>
 );
 
-const LearningTrainingToolbar = () => {
+const LearningTrainingToolbar: FC = () => {
 	const learningAssessment = useXPath(
 		xq`fonto:selection-common-ancestor()/ancestor-or-self::learningAssessment`,
 		null,

--- a/packages/dita-example-masthead/src/toolbars/QuestionToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/QuestionToolbar.tsx
@@ -1,19 +1,20 @@
+import type { FC } from 'react';
+import { useMemo } from 'react';
+
 import {
 	ButtonWithDrop,
 	Drop,
 	MastheadToolbar,
 	MastheadToolbarButtons,
 	Menu,
-} from 'fds/components';
-import React, { useMemo } from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 import FxOperationMenuItem from 'fontoxml-fx/src/FxOperationMenuItem';
 import useXPath from 'fontoxml-fx/src/useXPath';
 import ReturnTypes from 'fontoxml-selectors/src/ReturnTypes';
 import xq from 'fontoxml-selectors/src/xq';
 
-const QuestionToolbar = () => {
+const QuestionToolbar: FC = () => {
 	const matching = useXPath(
 		xq`fonto:selection-common-ancestor()/ancestor-or-self::lcMatching2`,
 		null,

--- a/packages/dita-example-masthead/src/toolbars/StartToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/StartToolbar.tsx
@@ -1,40 +1,48 @@
-import { MastheadToolbar, MastheadToolbarButtons } from 'fds/components';
-import * as React from 'react';
+import type { FC } from 'react';
 
+import {
+	MastheadToolbar,
+	MastheadToolbarButtons,
+} from 'fontoxml-design-system/src/components';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 
-const StartToolbar = () => (
-	<MastheadToolbar>
-		<MastheadToolbarButtons>
-			<FxOperationButton label="" operationName="cut" />
-			<FxOperationButton label="" operationName="copy" />
-			<FxOperationButton label="" operationName="paste" />
-		</MastheadToolbarButtons>
+const StartToolbar: FC = () => {
+	return (
+		<MastheadToolbar>
+			<MastheadToolbarButtons>
+				<FxOperationButton label="" operationName="cut" />
+				<FxOperationButton label="" operationName="copy" />
+				<FxOperationButton label="" operationName="paste" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton label="" operationName=":toggle-b" />
-			<FxOperationButton label="" operationName=":toggle-i" />
-			<FxOperationButton label="" operationName=":toggle-u" />
-			<FxOperationButton label="" operationName=":toggle-line-through" />
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<FxOperationButton label="" operationName=":toggle-b" />
+				<FxOperationButton label="" operationName=":toggle-i" />
+				<FxOperationButton label="" operationName=":toggle-u" />
+				<FxOperationButton
+					label=""
+					operationName=":toggle-line-through"
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton label="" operationName=":toggle-sub" />
-			<FxOperationButton label="" operationName=":toggle-sup" />
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<FxOperationButton label="" operationName=":toggle-sub" />
+				<FxOperationButton label="" operationName=":toggle-sup" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton label="" operationName=":insert-ul" />
-			<FxOperationButton label="" operationName=":insert-ol" />
-			<FxOperationButton label="" operationName=":insert-sl" />
-			<FxOperationButton label="" operationName="indent-list-item" />
-			<FxOperationButton label="" operationName="outdent-list-item" />
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<FxOperationButton label="" operationName=":insert-ul" />
+				<FxOperationButton label="" operationName=":insert-ol" />
+				<FxOperationButton label="" operationName=":insert-sl" />
+				<FxOperationButton label="" operationName="indent-list-item" />
+				<FxOperationButton label="" operationName="outdent-list-item" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName="default-special-character-insert" />
-		</MastheadToolbarButtons>
-	</MastheadToolbar>
-);
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName="default-special-character-insert" />
+			</MastheadToolbarButtons>
+		</MastheadToolbar>
+	);
+};
 
 export default StartToolbar;

--- a/packages/dita-example-masthead/src/toolbars/StructureToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/StructureToolbar.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import {
 	ButtonWithDrop,
 	Drop,
@@ -6,9 +8,7 @@ import {
 	Menu,
 	MenuGroup,
 	MenuItemWithDrop,
-} from 'fds/components';
-import * as React from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import FxMultiOperationsMenuItem from 'fontoxml-fx/src/FxMultiOperationsMenuItem';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 import FxOperationInsertTableMenu from 'fontoxml-fx/src/FxOperationInsertTableMenu';
@@ -17,196 +17,198 @@ import FxOperationsSplitButtonWithDropMenu from 'fontoxml-fx/src/FxOperationsSpl
 
 import InsertTopicMenu from '../menus/InsertTopicMenu.jsx';
 
-const StructureToolbar = () => (
-	<MastheadToolbar>
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				label="Insert topic"
-				renderDrop={() => (
-					<Drop>
-						<InsertTopicMenu />
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
+const StructureToolbar: FC = () => {
+	return (
+		<MastheadToolbar>
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					label="Insert topic"
+					renderDrop={() => (
+						<Drop>
+							<InsertTopicMenu />
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				label="Table"
-				icon="table"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<MenuItemWithDrop
-									label="Generic table"
-									renderDrop={() => (
-										<Drop>
-											<FxOperationInsertTableMenu operationName=":insert-cals-table" />
-										</Drop>
-									)}
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					label="Table"
+					icon="table"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<MenuItemWithDrop
+										label="Generic table"
+										renderDrop={() => (
+											<Drop>
+												<FxOperationInsertTableMenu operationName=":insert-cals-table" />
+											</Drop>
+										)}
+									/>
+
+									<MenuItemWithDrop
+										label="Simple table"
+										renderDrop={() => (
+											<Drop>
+												<FxOperationInsertTableMenu operationName="simpletable-insert" />
+											</Drop>
+										)}
+									/>
+
+									<MenuItemWithDrop
+										label="Simple table in figure"
+										renderDrop={() => (
+											<Drop>
+												<FxOperationInsertTableMenu operationName=":insert-fig.simpletable" />
+											</Drop>
+										)}
+									/>
+								</MenuGroup>
+
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-dl" />
+									<FxOperationMenuItem operationName=":insert-parml" />
+									<FxOperationMenuItem operationName=":insert-properties" />
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
+
+				<FxOperationsSplitButtonWithDropMenu
+					operations={[
+						{ operationName: ':insert-dl' },
+						{ operationName: ':insert-parml' },
+						{ operationName: ':insert-properties' },
+					]}
+				/>
+
+				<FxOperationsSplitButtonWithDropMenu
+					operations={[
+						{ operationName: ':insert-fig.image' },
+						{ operationName: ':insert-image' },
+					]}
+					tooltipContent="Any of the below"
+				/>
+
+				<FxOperationsSplitButtonWithDropMenu
+					operations={[
+						{ operationName: ':insert-equation-figure' },
+						{ operationName: ':insert-equation-block' },
+						{ operationName: ':insert-equation-inline' },
+					]}
+					tooltipContent="Any of the below"
+				/>
+			</MastheadToolbarButtons>
+
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					label="Intro"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<FxOperationMenuItem operationName=":insert-shortdesc" />
+								<FxOperationMenuItem operationName=":insert-abstract" />
+							</Menu>
+						</Drop>
+					)}
+				/>
+
+				<ButtonWithDrop
+					label="Section"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-section" />
+									<FxOperationMenuItem operationName=":insert-example" />
+								</MenuGroup>
+
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-refsyn" />
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
+
+				<ButtonWithDrop
+					label="Group"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<FxOperationMenuItem operationName=":insert-div" />
+								<FxMultiOperationsMenuItem
+									operations={[
+										{ operationName: ':insert-bodydiv' },
+										{ operationName: ':insert-conbodydiv' },
+										{ operationName: ':insert-refbodydiv' },
+									]}
 								/>
+								<FxOperationMenuItem operationName=":insert-sectiondiv" />
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
 
-								<MenuItemWithDrop
-									label="Simple table"
-									renderDrop={() => (
-										<Drop>
-											<FxOperationInsertTableMenu operationName="simpletable-insert" />
-										</Drop>
-									)}
-								/>
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					icon="sticky-note-o"
+					label="Note"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<FxOperationMenuItem
+										label="Generic note"
+										operationName=":insert-note--task"
+									/>
+								</MenuGroup>
 
-								<MenuItemWithDrop
-									label="Simple table in figure"
-									renderDrop={() => (
-										<Drop>
-											<FxOperationInsertTableMenu operationName=":insert-fig.simpletable" />
-										</Drop>
-									)}
-								/>
-							</MenuGroup>
+								<MenuGroup>
+									<FxOperationMenuItem operationName=":insert-note[@type=attention]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=caution]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=danger]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=fastpath]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=important]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=notice]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=remember]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=restriction]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=tip]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=warning]--task" />
+									<FxOperationMenuItem operationName=":insert-note[@type=other]--task" />
+								</MenuGroup>
 
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-dl" />
-								<FxOperationMenuItem operationName=":insert-parml" />
-								<FxOperationMenuItem operationName=":insert-properties" />
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
+								<MenuGroup>
+									<FxOperationMenuItem operationName="insert-note[@conref]" />
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
 
-			<FxOperationsSplitButtonWithDropMenu
-				operations={[
-					{ operationName: ':insert-dl' },
-					{ operationName: ':insert-parml' },
-					{ operationName: ':insert-properties' },
-				]}
-			/>
+				<FxOperationButton operationName=":insert-lq" />
+				<FxOperationButton operationName=":insert-fn" />
+			</MastheadToolbarButtons>
 
-			<FxOperationsSplitButtonWithDropMenu
-				operations={[
-					{ operationName: ':insert-fig.image' },
-					{ operationName: ':insert-image' },
-				]}
-				tooltipContent="Any of the below"
-			/>
-
-			<FxOperationsSplitButtonWithDropMenu
-				operations={[
-					{ operationName: ':insert-equation-figure' },
-					{ operationName: ':insert-equation-block' },
-					{ operationName: ':insert-equation-inline' },
-				]}
-				tooltipContent="Any of the below"
-			/>
-		</MastheadToolbarButtons>
-
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				label="Intro"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<FxOperationMenuItem operationName=":insert-shortdesc" />
-							<FxOperationMenuItem operationName=":insert-abstract" />
-						</Menu>
-					</Drop>
-				)}
-			/>
-
-			<ButtonWithDrop
-				label="Section"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-section" />
-								<FxOperationMenuItem operationName=":insert-example" />
-							</MenuGroup>
-
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-refsyn" />
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
-
-			<ButtonWithDrop
-				label="Group"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<FxOperationMenuItem operationName=":insert-div" />
-							<FxMultiOperationsMenuItem
-								operations={[
-									{ operationName: ':insert-bodydiv' },
-									{ operationName: ':insert-conbodydiv' },
-									{ operationName: ':insert-refbodydiv' },
-								]}
-							/>
-							<FxOperationMenuItem operationName=":insert-sectiondiv" />
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
-
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				icon="sticky-note-o"
-				label="Note"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<FxOperationMenuItem
-									label="Generic note"
-									operationName=":insert-note--task"
-								/>
-							</MenuGroup>
-
-							<MenuGroup>
-								<FxOperationMenuItem operationName=":insert-note[@type=attention]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=caution]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=danger]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=fastpath]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=important]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=notice]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=remember]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=restriction]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=tip]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=warning]--task" />
-								<FxOperationMenuItem operationName=":insert-note[@type=other]--task" />
-							</MenuGroup>
-
-							<MenuGroup>
-								<FxOperationMenuItem operationName="insert-note[@conref]" />
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
-
-			<FxOperationButton operationName=":insert-lq" />
-			<FxOperationButton operationName=":insert-fn" />
-		</MastheadToolbarButtons>
-
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				label="Related links"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<FxOperationMenuItem operationName=":insert-link[@format=html]" />
-							<FxOperationMenuItem operationName=":insert-link[@format=dita]" />
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
-	</MastheadToolbar>
-);
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					label="Related links"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<FxOperationMenuItem operationName=":insert-link[@format=html]" />
+								<FxOperationMenuItem operationName=":insert-link[@format=dita]" />
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
+		</MastheadToolbar>
+	);
+};
 
 export default StructureToolbar;

--- a/packages/dita-example-masthead/src/toolbars/TaskToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/TaskToolbar.tsx
@@ -1,60 +1,62 @@
+import type { FC } from 'react';
+
 import {
 	ButtonWithDrop,
 	Drop,
 	MastheadToolbar,
 	MastheadToolbarButtons,
 	Menu,
-} from 'fds/components';
-import * as React from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 import FxOperationMenuItem from 'fontoxml-fx/src/FxOperationMenuItem';
 import FxOperationsSplitButtonWithDropMenu from 'fontoxml-fx/src/FxOperationsSplitButtonWithDropMenu';
 
-const TaskToolbar = () => (
-	<MastheadToolbar>
-		<MastheadToolbarButtons>
-			<ButtonWithDrop
-				label="Task"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<FxOperationMenuItem operationName=":insert-prereq" />
-							<FxOperationMenuItem operationName=":insert-context" />
-							<FxOperationMenuItem operationName=":insert-steps" />
-							<FxOperationMenuItem operationName=":insert-steps-unordered" />
-							<FxOperationMenuItem operationName=":insert-steps-informal" />
-							<FxOperationMenuItem operationName=":insert-result" />
-							<FxOperationMenuItem operationName=":insert-tasktroubleshooting" />
-							<FxOperationMenuItem operationName=":insert-example--task" />
-							<FxOperationMenuItem operationName=":insert-postreq" />
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
+const TaskToolbar: FC = () => {
+	return (
+		<MastheadToolbar>
+			<MastheadToolbarButtons>
+				<ButtonWithDrop
+					label="Task"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<FxOperationMenuItem operationName=":insert-prereq" />
+								<FxOperationMenuItem operationName=":insert-context" />
+								<FxOperationMenuItem operationName=":insert-steps" />
+								<FxOperationMenuItem operationName=":insert-steps-unordered" />
+								<FxOperationMenuItem operationName=":insert-steps-informal" />
+								<FxOperationMenuItem operationName=":insert-result" />
+								<FxOperationMenuItem operationName=":insert-tasktroubleshooting" />
+								<FxOperationMenuItem operationName=":insert-example--task" />
+								<FxOperationMenuItem operationName=":insert-postreq" />
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":insert-stepsection" />
-			<FxOperationButton operationName=":insert-step" />
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":insert-stepsection" />
+				<FxOperationButton operationName=":insert-step" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName=":insert-note--task" />
-			<FxOperationsSplitButtonWithDropMenu
-				operations={[
-					{ operationName: ':insert-info' },
-					{ operationName: ':insert-tutorialinfo' },
-				]}
-			/>
-			<FxOperationButton operationName=":insert-stepxmp" />
-			<FxOperationButton operationName=":insert-choices" />
-			<FxOperationButton operationName=":insert-choicetable" />
-			<FxOperationButton operationName=":insert-substeps" />
-			<FxOperationButton operationName=":insert-stepresult" />
-			<FxOperationButton operationName=":insert-steptroubleshooting" />
-		</MastheadToolbarButtons>
-	</MastheadToolbar>
-);
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName=":insert-note--task" />
+				<FxOperationsSplitButtonWithDropMenu
+					operations={[
+						{ operationName: ':insert-info' },
+						{ operationName: ':insert-tutorialinfo' },
+					]}
+				/>
+				<FxOperationButton operationName=":insert-stepxmp" />
+				<FxOperationButton operationName=":insert-choices" />
+				<FxOperationButton operationName=":insert-choicetable" />
+				<FxOperationButton operationName=":insert-substeps" />
+				<FxOperationButton operationName=":insert-stepresult" />
+				<FxOperationButton operationName=":insert-steptroubleshooting" />
+			</MastheadToolbarButtons>
+		</MastheadToolbar>
+	);
+};
 
 export default TaskToolbar;

--- a/packages/dita-example-masthead/src/toolbars/ToolsToolbar.tsx
+++ b/packages/dita-example-masthead/src/toolbars/ToolsToolbar.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import {
 	ButtonWithDrop,
 	Drop,
@@ -5,73 +7,73 @@ import {
 	MastheadToolbarButtons,
 	Menu,
 	MenuGroup,
-} from 'fds/components';
-import * as React from 'react';
-
+} from 'fontoxml-design-system/src/components';
 import FxMultiOperationsMenuItem from 'fontoxml-fx/src/FxMultiOperationsMenuItem';
 import FxOperationButton from 'fontoxml-fx/src/FxOperationButton';
 import FxOperationMenuItem from 'fontoxml-fx/src/FxOperationMenuItem';
 
-const ToolsToolbar = () => (
-	<MastheadToolbar>
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName="toggle-display-mode-document" />
+const ToolsToolbar: FC = () => {
+	return (
+		<MastheadToolbar>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName="toggle-display-mode-document" />
 
-			<ButtonWithDrop
-				icon="search"
-				label="Zoom"
-				renderDrop={() => (
-					<Drop>
-						<Menu>
-							<MenuGroup>
-								<FxOperationMenuItem operationName="zoom-content-view-to-75%-75%" />
-								<FxOperationMenuItem operationName="zoom-content-view-to-100%-100%" />
-								<FxOperationMenuItem operationName="zoom-content-view-to-125%-125%" />
-								<FxOperationMenuItem operationName="zoom-content-view-to-150%-150%" />
-								<FxOperationMenuItem operationName="zoom-content-view-to-200%-200%" />
-							</MenuGroup>
+				<ButtonWithDrop
+					icon="search"
+					label="Zoom"
+					renderDrop={() => (
+						<Drop>
+							<Menu>
+								<MenuGroup>
+									<FxOperationMenuItem operationName="zoom-content-view-to-75%-75%" />
+									<FxOperationMenuItem operationName="zoom-content-view-to-100%-100%" />
+									<FxOperationMenuItem operationName="zoom-content-view-to-125%-125%" />
+									<FxOperationMenuItem operationName="zoom-content-view-to-150%-150%" />
+									<FxOperationMenuItem operationName="zoom-content-view-to-200%-200%" />
+								</MenuGroup>
 
-							<MenuGroup>
-								<FxMultiOperationsMenuItem
-									operations={[
-										{
-											operationName:
-												'wide-canvas-content-view-to-150%-text-size-not-150%',
-										},
-										{
-											operationName:
-												'untoggle-wide-canvas-content-view-to-150%-text-size-not-150%',
-										},
-									]}
-								/>
-							</MenuGroup>
-						</Menu>
-					</Drop>
-				)}
-			/>
-		</MastheadToolbarButtons>
+								<MenuGroup>
+									<FxMultiOperationsMenuItem
+										operations={[
+											{
+												operationName:
+													'wide-canvas-content-view-to-150%-text-size-not-150%',
+											},
+											{
+												operationName:
+													'untoggle-wide-canvas-content-view-to-150%-text-size-not-150%',
+											},
+										]}
+									/>
+								</MenuGroup>
+							</Menu>
+						</Drop>
+					)}
+				/>
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton operationName="toggle-spell-checker" />
-		</MastheadToolbarButtons>
+			<MastheadToolbarButtons>
+				<FxOperationButton operationName="toggle-spell-checker" />
+			</MastheadToolbarButtons>
 
-		<MastheadToolbarButtons>
-			<FxOperationButton
-				icon="align-right icon-flip-vertical"
-				label="Outline"
-				operationName="toggle-structure-view"
-				tooltipContent="Document outline"
-			/>
+			<MastheadToolbarButtons>
+				<FxOperationButton
+					icon="align-right icon-flip-vertical"
+					label="Outline"
+					operationName="toggle-structure-view"
+					tooltipContent="Document outline"
+				/>
 
-			<FxOperationButton
-				icon="code"
-				label="Source"
-				operationData={{ tabId: 'source' }}
-				operationName="toggle-sidebar-tab"
-				tooltipContent="XML source code"
-			/>
-		</MastheadToolbarButtons>
-	</MastheadToolbar>
-);
+				<FxOperationButton
+					icon="code"
+					label="Source"
+					operationData={{ tabId: 'source' }}
+					operationName="toggle-sidebar-tab"
+					tooltipContent="XML source code"
+				/>
+			</MastheadToolbarButtons>
+		</MastheadToolbar>
+	);
+};
 
 export default ToolsToolbar;

--- a/packages/dita-example-structure-view/src/configureSxModule.ts
+++ b/packages/dita-example-structure-view/src/configureSxModule.ts
@@ -38,7 +38,7 @@ function formatContextualOperationListWithGroups(list) {
 	}));
 }
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	sxModule.markAsAddon();
 
 	// Configure DITA elements that extend the map/topicref/topic classes to show up in

--- a/packages/dita-example-sx-integration/src/configureSxModule.ts
+++ b/packages/dita-example-sx-integration/src/configureSxModule.ts
@@ -10,7 +10,7 @@ import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidg
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// Mark this configureSxModule.js file as an addon entry file, so that we don't have to explicitly depend on
 	// this package from an *-sx-shell. The best practice is to always depend on the specific *-sx-module packages
 	// from your own shell.

--- a/packages/dita-example-sx-integration/src/install.ts
+++ b/packages/dita-example-sx-integration/src/install.ts
@@ -1,6 +1,6 @@
 import addTransform from 'fontoxml-operations/src/addTransform';
 
-export default function install() {
+export default function install(): void {
 	addTransform(
 		'unsetSelectedImageIdForGetState',
 		function (stepData) {

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-assessment-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-assessment-mod/src/configureSxModule.ts
@@ -9,7 +9,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// learningAssessment
 	//     A Learning Assessment presents questions or interactions that measure progress, encourage
 	//     recollection, and stimulate reinforcement of the learning content, and can be presented before the

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.ts
@@ -12,7 +12,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// lcAudience
 	//     The <lcAudience> describes characteristics of the learners who take the instruction.
 	configureAsFrame(sxModule, xq`self::lcAudience`, t('audience'), {

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/install.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/install.ts
@@ -2,6 +2,6 @@ import uiManager from 'fontoxml-modular-ui/src/uiManager';
 
 import TimeValueModal from './ui/TimeValueModal.jsx';
 
-export default function install() {
+export default function install(): void {
 	uiManager.registerReactComponent('TimeValueModal', TimeValueModal);
 }

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/ui/TimeValueModal.tsx
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/ui/TimeValueModal.tsx
@@ -1,3 +1,6 @@
+import type { ReactElement } from 'react';
+import { Component } from 'react';
+
 import {
 	Button,
 	Form,
@@ -7,9 +10,7 @@ import {
 	ModalFooter,
 	ModalHeader,
 	TextInput,
-} from 'fds/components';
-import { Component } from 'react';
-import * as React from 'react';
+} from 'fontoxml-design-system/src/components';
 
 class TimeValueModal extends Component<{
 	cancelModal(): void;
@@ -53,7 +54,7 @@ class TimeValueModal extends Component<{
 	private readonly handleTextInputRef = (textInputRef) =>
 		(this.textInputRef = textInputRef);
 
-	public render() {
+	public render(): ReactElement {
 		return (
 			<Modal size="s" onKeyDown={this.handleKeyDown}>
 				<ModalHeader icon="clock-o" title="Enter the time duration" />
@@ -86,7 +87,7 @@ class TimeValueModal extends Component<{
 		);
 	}
 
-	public componentDidMount() {
+	public componentDidMount(): void {
 		this.textInputRef.focus();
 	}
 }

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-content-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-content-mod/src/configureSxModule.ts
@@ -9,7 +9,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// learningContent
 	//     A Learning Content topic provides the learning content itself, and enables direct use of content
 	//     from DITA task, concept, and reference topics, as well as additional content of any topic type that

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-interaction-base2domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-interaction-base2domain/src/configureSxModule.ts
@@ -4,7 +4,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// lcInteractionBase2
 	configureAsRemoved(
 		sxModule,

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-overview-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-overview-mod/src/configureSxModule.ts
@@ -9,7 +9,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// learningOverview
 	//     A Learning Overview topic identifies the learning objectives, includes other information helpful to
 	//     the learner, such as prerequisites, duration, intended audience, and can include information and

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.ts
@@ -12,7 +12,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// lcAge
 	//     The <lcAge> provides the age range of the intended learner audience, for use by curriculum
 	//     developers and course planners.

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-summary-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-summary-mod/src/configureSxModule.ts
@@ -9,7 +9,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// learningSummary
 	//     A Learning Summary recaps and provides context for the achievement or accomplishment of learning
 	//     objectives, provides guidance to reinforce learning and long-term memory, and may pose questions to

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/insertNodeAndRemoveFromSiblingsCustomMutation.ts
@@ -1,5 +1,7 @@
 import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult';
+import type Blueprint from 'fontoxml-blueprints/src/Blueprint';
 import blueprintQuery from 'fontoxml-blueprints/src/blueprintQuery';
+import type { OperationStepData } from 'fontoxml-operations/src/types';
 import evaluateXPathToFirstNode from 'fontoxml-selectors/src/evaluateXPathToFirstNode';
 import evaluateXPathToNodes from 'fontoxml-selectors/src/evaluateXPathToNodes';
 import xq from 'fontoxml-selectors/src/xq';
@@ -11,21 +13,28 @@ import xq from 'fontoxml-selectors/src/xq';
  * @param {string | XQExpression} referenceNodeQuery   An XPath Query or XQExpression to find a node
  * 										               which should become the next sibling of the new node.
  */
-export default function insertNodeAndRemoveFromSiblings(argument, blueprint) {
-	const contextNode = blueprint.lookup(argument.contextNodeId);
+export default function insertNodeAndRemoveFromSiblings(
+	stepData: OperationStepData & {
+		contextNodeId: string;
+		nodeName: string;
+		referenceNodeQuery: string;
+	},
+	blueprint: Blueprint
+): CustomMutationResult {
+	const contextNode = blueprint.lookup(stepData.contextNodeId);
 	if (
 		!contextNode ||
-		!argument.nodeName ||
+		!stepData.nodeName ||
 		!blueprintQuery.isInDocument(blueprint, contextNode)
 	) {
 		return CustomMutationResult.notAllowed();
 	}
 
 	const documentNode = blueprintQuery.getDocumentNode(blueprint, contextNode);
-	const newNode = documentNode.createElement(argument.nodeName);
-	const referenceNode = argument.referenceNodeQuery
+	const newNode = documentNode.createElement(stepData.nodeName);
+	const referenceNode = stepData.referenceNodeQuery
 		? evaluateXPathToFirstNode(
-				argument.referenceNodeQuery,
+				stepData.referenceNodeQuery,
 				contextNode,
 				blueprint
 		  )
@@ -43,7 +52,7 @@ export default function insertNodeAndRemoveFromSiblings(argument, blueprint) {
 		)
 		.forEach(function (siblingNode) {
 			const removeNode = evaluateXPathToFirstNode(
-				xq`child::*[name() = ${argument.nodeName}]`,
+				xq`child::*[name() = ${stepData.nodeName}]`,
 				siblingNode,
 				blueprint
 			);

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/replaceNodesWithMappedStructureCustomMutation.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/api/replaceNodesWithMappedStructureCustomMutation.ts
@@ -1,5 +1,9 @@
 import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult';
+import type Blueprint from 'fontoxml-blueprints/src/Blueprint';
 import blueprintQuery from 'fontoxml-blueprints/src/blueprintQuery';
+import type BlueprintSelection from 'fontoxml-blueprints/src/BlueprintSelection';
+import type { OperationStepData } from 'fontoxml-operations/src/types';
+import type { Format } from 'fontoxml-schema-experience/src/format';
 import evaluateXPathToFirstNode from 'fontoxml-selectors/src/evaluateXPathToFirstNode';
 import createStencil from 'fontoxml-stencils/src/createStencil';
 
@@ -16,11 +20,13 @@ import createStencil from 'fontoxml-stencils/src/createStencil';
  * @param {Object} queryToReplacementStructureMapping
  */
 export default function replaceNodesWithMappedStructure(
-	stepData,
-	blueprint,
-	format,
-	selection
-) {
+	stepData: OperationStepData & {
+		contextNodeId: string;
+	},
+	blueprint: Blueprint,
+	format: Format,
+	selection: BlueprintSelection
+): CustomMutationResult {
 	const contextNode = blueprint.lookup(stepData.contextNodeId);
 	const documentNode = blueprintQuery.getDocumentNode(
 		blueprint,

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/configureSxModule.ts
@@ -11,7 +11,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// lcAnswerContent2
 	//     The <lcAnswerContent2> element in a learning assessment interaction provides the content for an
 	//     answer option, which the learner can select as correct or incorrect.

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/replaceBooktitleWithTitle.ts
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/replaceBooktitleWithTitle.ts
@@ -1,14 +1,25 @@
 import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult';
 import { convertElement } from 'fontoxml-base-flow/src/primitives';
+import type Blueprint from 'fontoxml-blueprints/src/Blueprint';
 import { unsafeCollapseElement } from 'fontoxml-blueprints/src/blueprintMutations';
 import blueprintQuery from 'fontoxml-blueprints/src/blueprintQuery';
+import type BlueprintSelection from 'fontoxml-blueprints/src/BlueprintSelection';
 import type { FontoElementNode } from 'fontoxml-dom-utils/src/types';
+import type { OperationStepData } from 'fontoxml-operations/src/types';
+import type { Format } from 'fontoxml-schema-experience/src/format';
 import evaluateXPathToBoolean from 'fontoxml-selectors/src/evaluateXPathToBoolean';
 import evaluateXPathToFirstNode from 'fontoxml-selectors/src/evaluateXPathToFirstNode';
 import xq from 'fontoxml-selectors/src/xq';
 
-const replaceBooktitleWithTitle = (argument, blueprint, format, _selection) => {
-	const booktitleNode = blueprint.lookup(argument.contextNodeId);
+const replaceBooktitleWithTitle = (
+	stepData: OperationStepData & {
+		contextNodeId: string;
+	},
+	blueprint: Blueprint,
+	format: Format,
+	_selection: BlueprintSelection
+): CustomMutationResult => {
+	const booktitleNode = blueprint.lookup(stepData.contextNodeId);
 
 	if (
 		!booktitleNode ||

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/replaceTitleWithBooktitle.ts
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/replaceTitleWithBooktitle.ts
@@ -1,11 +1,22 @@
 import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult';
 import { convertElement } from 'fontoxml-base-flow/src/primitives';
+import type Blueprint from 'fontoxml-blueprints/src/Blueprint';
 import { unsafeMoveNodes } from 'fontoxml-blueprints/src/blueprintMutations';
 import blueprintQuery from 'fontoxml-blueprints/src/blueprintQuery';
+import type BlueprintSelection from 'fontoxml-blueprints/src/BlueprintSelection';
 import namespaceManager from 'fontoxml-dom-namespaces/src/namespaceManager';
+import type { OperationStepData } from 'fontoxml-operations/src/types';
+import type { Format } from 'fontoxml-schema-experience/src/format';
 
-const replaceTitleWithBooktitle = (argument, blueprint, format, _selection) => {
-	const titleNode = blueprint.lookup(argument.contextNodeId);
+const replaceTitleWithBooktitle = (
+	stepData: OperationStepData & {
+		contextNodeId: string;
+	},
+	blueprint: Blueprint,
+	format: Format,
+	_selection: BlueprintSelection
+): CustomMutationResult => {
+	const titleNode = blueprint.lookup(stepData.contextNodeId);
 
 	if (!titleNode || !blueprintQuery.isInDocument(blueprint, titleNode)) {
 		return CustomMutationResult.notAllowed().setActive();

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/wrapAppendixElementsInAppendices.ts
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/api/wrapAppendixElementsInAppendices.ts
@@ -1,12 +1,20 @@
 import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult';
+import type Blueprint from 'fontoxml-blueprints/src/Blueprint';
 import { unsafeMoveNodes } from 'fontoxml-blueprints/src/blueprintMutations';
 import blueprintQuery from 'fontoxml-blueprints/src/blueprintQuery';
 import namespaceManager from 'fontoxml-dom-namespaces/src/namespaceManager';
+import type { OperationStepData } from 'fontoxml-operations/src/types';
 import evaluateXPathToNodes from 'fontoxml-selectors/src/evaluateXPathToNodes';
 import xq from 'fontoxml-selectors/src/xq';
 
-const wrapAppendixElementsInAppendices = (argument, blueprint) => {
-	const bookmapNode = blueprint.lookup(argument.contextNodeId);
+const wrapAppendixElementsInAppendices = (
+	stepData: OperationStepData & {
+		contextNodeId: string;
+		href: string;
+	},
+	blueprint: Blueprint
+): CustomMutationResult => {
+	const bookmapNode = blueprint.lookup(stepData.contextNodeId);
 
 	if (!bookmapNode || !blueprintQuery.isInDocument(blueprint, bookmapNode)) {
 		return CustomMutationResult.notAllowed();
@@ -27,8 +35,8 @@ const wrapAppendixElementsInAppendices = (argument, blueprint) => {
 		'appendices'
 	);
 
-	if (argument.href) {
-		blueprint.setAttribute(appendicesNode, 'href', argument.href);
+	if (stepData.href) {
+		blueprint.setAttribute(appendicesNode, 'href', stepData.href);
 	}
 
 	blueprint.insertBefore(bookmapNode, appendicesNode, appendixNodes[0]);

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/configureSxModule.ts
@@ -153,7 +153,7 @@ const getSubMenuForRefElement = (
 	],
 });
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	namespaceManager.addNamespace('bookmap', 'urn:fonto:dita:bookmap');
 	registerCustomXPathFunction(
 		'bookmap:retrieve-element-label',

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/install.ts
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/install.ts
@@ -6,7 +6,7 @@ import type { DocumentId } from 'fontoxml-documents/src/types';
 import type { FontoDocumentNode } from 'fontoxml-dom-utils/src/types';
 import addAction, { CANCEL_OPERATION } from 'fontoxml-operations/src/addAction';
 import addTransform from 'fontoxml-operations/src/addTransform';
-import type { StepData } from 'fontoxml-operations/src/types';
+import type { OperationStepData } from 'fontoxml-operations/src/types';
 import documentLoader from 'fontoxml-remote-documents/src/documentLoader';
 import type { RemoteDocumentId } from 'fontoxml-remote-documents/src/types';
 import evaluateXPathToBoolean from 'fontoxml-selectors/src/evaluateXPathToBoolean';
@@ -17,7 +17,7 @@ import replaceTitleWithBooktitle from './api/replaceTitleWithBooktitle';
 import wrapAppendixElementsInAppendices from './api/wrapAppendixElementsInAppendices';
 
 async function isDocumentAMapPromise(
-	stepData: StepData &
+	stepData: OperationStepData &
 		(
 			| { documentId: DocumentId }
 			| { remoteDocumentId: RemoteDocumentId }
@@ -54,7 +54,7 @@ async function isDocumentAMapPromise(
 	return false;
 }
 
-export default function install() {
+export default function install(): void {
 	addCustomMutation(
 		'replace-title-with-booktitle',
 		replaceTitleWithBooktitle

--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureImageWithoutPermanentId.ts
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureImageWithoutPermanentId.ts
@@ -5,7 +5,9 @@ import xq from 'fontoxml-selectors/src/xq';
 
 // This file removes the permanentId which is the other way around then for cross reference,
 // for compatability reasons.
-export default function configureImageWithoutPermanentId(sxModule: SxModule) {
+export default function configureImageWithoutPermanentId(
+	sxModule: SxModule
+): void {
 	// To disable permanentId's in images (also known as the reference pipeline), set
 	// isPermanentId to false.
 

--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.ts
@@ -1,4 +1,4 @@
-import { ListStyles } from 'fontoxml-list-flow/src/configureAsListElements';
+import configureAsSimpletableTableElements from 'fontoxml-dita/src/configureAsSimpletableTableElements';
 import configureAsBlock from 'fontoxml-families/src/configureAsBlock';
 import configureAsDefinitionsTableRow from 'fontoxml-families/src/configureAsDefinitionsTableRow';
 import configureAsFrame from 'fontoxml-families/src/configureAsFrame';
@@ -11,9 +11,7 @@ import configureAsInlineImageInFrame from 'fontoxml-families/src/configureAsInli
 import configureAsInlineLink from 'fontoxml-families/src/configureAsInlineLink';
 import configureAsInlineObject from 'fontoxml-families/src/configureAsInlineObject';
 import configureAsInlineStructure from 'fontoxml-families/src/configureAsInlineStructure';
-import configureAsListElements from 'fontoxml-list-flow/src/configureAsListElements';
 import configureAsRemoved from 'fontoxml-families/src/configureAsRemoved';
-import configureAsSimpletableTableElements from 'fontoxml-dita/src/configureAsSimpletableTableElements';
 import configureAsStructure from 'fontoxml-families/src/configureAsStructure';
 import configureAsTitleFrame from 'fontoxml-families/src/configureAsTitleFrame';
 import configureContextualOperations from 'fontoxml-families/src/configureContextualOperations';
@@ -21,11 +19,14 @@ import configureMarkupLabel from 'fontoxml-families/src/configureMarkupLabel';
 import configureProperties from 'fontoxml-families/src/configureProperties';
 import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMenuButtonWidget';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget';
+import configureAsListElements, {
+	ListStyles,
+} from 'fontoxml-list-flow/src/configureAsListElements';
 import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// alt
 	//     The alt element provides alternate text for an image. It is equivalent to the alt attribute on the
 	//     image element; the attribute is deprecated, so the alt element should be used instead. As an

--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureXrefToUsePermanentId.ts
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureXrefToUsePermanentId.ts
@@ -1,8 +1,11 @@
 import configureAsInlineLink from 'fontoxml-families/src/configureAsInlineLink';
 import configureProperties from 'fontoxml-families/src/configureProperties';
+import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureXrefToUsePermanentId(sxModule) {
+export default function configureXrefToUsePermanentId(
+	sxModule: SxModule
+): void {
 	// To enable permanentId's in cross references (also known as the reference pipeline), reconfigure the attribute
 	// name that is expected to contain the permanentId, and set popoverData.targetIsPermanent to TRUE.
 

--- a/packages/dita-example-sx-modules-xsd-concept-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-concept-mod/src/configureSxModule.ts
@@ -10,7 +10,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// conbody
 	//     The <conbody> element is the main body-level element for a concept. Like the <body> element of a
 	//     general <topic>, <conbody> allows paragraphs, lists, and other elements as well as sections and

--- a/packages/dita-example-sx-modules-xsd-equation-domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-equation-domain/src/configureSxModule.ts
@@ -8,7 +8,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// equation-block
 	//     The Block Equation element (<equation-block>) represents an equation to be rendered as a block.
 	//     Block equations may be numbered. The equation content may be represented in any number of ways,

--- a/packages/dita-example-sx-modules-xsd-glossentry-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-glossentry-mod/src/configureSxModule.ts
@@ -11,7 +11,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// glossAbbreviation
 	//     The <glossAbbreviation> element provides an abbreviated form of the term contained in a <glossterm>
 	//     element.

--- a/packages/dita-example-sx-modules-xsd-glossgroup-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-glossgroup-mod/src/configureSxModule.ts
@@ -7,7 +7,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// glossgroup
 	//     The <glossgroup> element may be used to contain multiple <glossentry> topics within a single
 	//     collection.

--- a/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureHazardsymbolWithoutPermanentId.ts
+++ b/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureHazardsymbolWithoutPermanentId.ts
@@ -6,7 +6,7 @@ import xq from 'fontoxml-selectors/src/xq';
 // for compatability reasons.
 export default function configureHazardSymbolWithoutPermanentId(
 	sxModule: SxModule
-) {
+): void {
 	// To disable permanentId's in hazard symbols (also known as the reference pipeline), set
 	// isPermanentId to false.
 

--- a/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-hazard-domain/src/configureSxModule.ts
@@ -9,7 +9,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// consequence
 	//     The <consequence> element is the container for the second text entry of a safety label. It contains
 	//     the description of the consequences of not avoiding the hazard, such as "Keep guard in place".

--- a/packages/dita-example-sx-modules-xsd-highlight-domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-highlight-domain/src/configureSxModule.ts
@@ -3,7 +3,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// b
 	//     The bold (<b>) element is used to apply bold highlighting to the content of the element. Use this
 	//     element only when there is not some other more proper element. For example, for specific items such

--- a/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.ts
@@ -7,7 +7,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// anchorref
 	//     The contents of an <anchorref> element are rendered both in the original authored location and at
 	//     the location of the referenced <anchor> element. The referenced <anchor> element can be defined in

--- a/packages/dita-example-sx-modules-xsd-map-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-map-mod/src/configureSxModule.ts
@@ -8,7 +8,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// anchor
 	configureAsRemoved(sxModule, xq`self::anchor`, t('anchor'));
 

--- a/packages/dita-example-sx-modules-xsd-mathml-domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-mathml-domain/src/configureSxModule.ts
@@ -6,7 +6,7 @@ import configureAsMathMlContainer from 'fontoxml-mathml/src/configureAsMathMlCon
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// mathml
 	//     The MathML container (<mathml>) element contains inline MathML markup or references to MathML
 	//     elements stored in a separate non-DITA XML document. The purpose of this element is simply to

--- a/packages/dita-example-sx-modules-xsd-programming-domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-programming-domain/src/configureSxModule.ts
@@ -12,7 +12,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// apiname
 	//     The <apiname> element provides the name of an application programming interface (API) such as a Java
 	//     class name or method name. This element is part of the DITA programming domain, a special set of

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/api/removePropertiesColumnCustomMutation.ts
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/api/removePropertiesColumnCustomMutation.ts
@@ -1,5 +1,7 @@
 import CustomMutationResult from 'fontoxml-base-flow/src/CustomMutationResult';
+import type Blueprint from 'fontoxml-blueprints/src/Blueprint';
 import blueprintQuery from 'fontoxml-blueprints/src/blueprintQuery';
+import type { OperationData } from 'fontoxml-operations/src/types';
 import evaluateXPathToNodes from 'fontoxml-selectors/src/evaluateXPathToNodes';
 import xq from 'fontoxml-selectors/src/xq';
 
@@ -13,7 +15,12 @@ import xq from 'fontoxml-selectors/src/xq';
  * @param  {NodeId}     stepData.contextNodeId  The internal identifier of one of the cells of the column to remove.
  * @param  {Blueprint}  blueprint               Provided by Fonto.
  */
-export default function removePropertiesColumn(stepData, blueprint) {
+export default function removePropertiesColumn(
+	stepData: OperationData & {
+		contextNodeId: string;
+	},
+	blueprint: Blueprint
+): CustomMutationResult {
 	const contextNode = blueprint.lookup(stepData.contextNodeId);
 	if (!contextNode || !blueprintQuery.isInDocument(blueprint, contextNode)) {
 		return CustomMutationResult.notAllowed();
@@ -22,10 +29,9 @@ export default function removePropertiesColumn(stepData, blueprint) {
 	// When removing a given element, we are also interested in removing the corresponding header element, and vice
 	// versa.
 	const contextNodeName = contextNode.nodeName;
-	const otherNodeName =
-		contextNodeName.slice(-2) === 'hd'
-			? contextNodeName.slice(0, -2)
-			: `${contextNodeName}hd`;
+	const otherNodeName = contextNodeName.endsWith('hd')
+		? contextNodeName.slice(0, -2)
+		: `${contextNodeName}hd`;
 
 	// Query the relevant node names in all rows of the same properties table
 	const columnNodes = evaluateXPathToNodes(

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.ts
@@ -13,7 +13,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// propdesc
 	//     The <propdesc> element is used to provide a short description of the property type and its listed
 	//     values (or just the value). Category: Reference elements

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/install.ts
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/install.ts
@@ -2,12 +2,13 @@ import addCustomMutation from 'fontoxml-base-flow/src/addCustomMutation';
 import readOnlyBlueprint from 'fontoxml-blueprints/src/readOnlyBlueprint';
 import documentsManager from 'fontoxml-documents/src/documentsManager';
 import addTransform from 'fontoxml-operations/src/addTransform';
+import type { OperationStepData } from 'fontoxml-operations/src/types';
 import evaluateXPathToBoolean from 'fontoxml-selectors/src/evaluateXPathToBoolean';
 import xq from 'fontoxml-selectors/src/xq';
 
 import removePropertiesColumn from './api/removePropertiesColumnCustomMutation';
 
-export default function install() {
+export default function install(): void {
 	addCustomMutation('remove-properties-column', removePropertiesColumn);
 
 	/**
@@ -22,7 +23,9 @@ export default function install() {
 	 */
 	addTransform(
 		'setChildNodeStructureForExistingColumns',
-		function setChildNodeStructureForExistingColumns(stepData) {
+		function setChildNodeStructureForExistingColumns(
+			stepData: OperationStepData
+		) {
 			const tableNode = documentsManager.getNodeById(
 				stepData.tableNodeId
 			);

--- a/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.ts
@@ -17,7 +17,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// chdesc
 	//     The <chdesc> element is a description of an option that a user chooses while performing a step to
 	//     accomplish a task. It explains why the user would choose that option, and might explain the result

--- a/packages/dita-example-sx-modules-xsd-tbl-decl-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-tbl-decl-mod/src/configureSxModule.ts
@@ -6,7 +6,7 @@ import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager'
 import xq from 'fontoxml-selectors/src/xq';
 import configureAsCalsTableElements from 'fontoxml-table-flow-cals/src/configureAsCalsTableElements';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// CALS table
 	configureAsCalsTableElements(sxModule, {
 		table: {

--- a/packages/dita-example-sx-modules-xsd-topic-mod/src/configureRelatedLinkToUsePermanentId.ts
+++ b/packages/dita-example-sx-modules-xsd-topic-mod/src/configureRelatedLinkToUsePermanentId.ts
@@ -1,9 +1,12 @@
 import configureAsRelatedLink from 'fontoxml-dita/src/configureAsRelatedLink';
 import createElementMenuButtonWidget from 'fontoxml-families/src/createElementMenuButtonWidget';
 import createMarkupLabelWidget from 'fontoxml-families/src/createMarkupLabelWidget';
+import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureXrefToUsePermanentId(sxModule) {
+export default function configureXrefToUsePermanentId(
+	sxModule: SxModule
+): void {
 	// To enable permanentId's in references (also known as the reference pipeline), change
 	// hasPermanentId to TRUE, and set popoverData.targetIsPermanent to TRUE.
 

--- a/packages/dita-example-sx-modules-xsd-topic-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-topic-mod/src/configureSxModule.ts
@@ -15,7 +15,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// abstract
 	//     The abstract element occurs between the topic title and the topic body, as the initial content of a
 	//     topic. It can contain paragraph-level content as well as one or more shortdesc elements which can be

--- a/packages/dita-example-sx-modules-xsd-ui-domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-ui-domain/src/configureSxModule.ts
@@ -8,7 +8,7 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// menucascade
 	//     The <menucascade> element is used to document a series of menu choices. The <menucascade> element
 	//     contains one or more user interface control (<uicontrol>) elements, for example: Start > Programs >

--- a/packages/dita-example-sx-pivot-model-translation/src/configureSxModule.ts
+++ b/packages/dita-example-sx-pivot-model-translation/src/configureSxModule.ts
@@ -2,7 +2,7 @@ import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager'
 import pivotModelTransformerManager from 'fontoxml-pivot-model/src/pivotModelTransformerManager';
 import PivotNodeTypes from 'fontoxml-pivot-model/src/PivotNodeTypes';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	// This is the configuration for transforming clipboard data, for example from MS Word or your browser, into
 	// the logical default DITA structure.
 	//
@@ -13,7 +13,7 @@ export default function configureSxModule(sxModule: SxModule) {
 			figureQualifiedName: 'table',
 			qualifiedName: 'tgroup',
 			isTable: true,
-			cellQualifiedName: 'entry'
+			cellQualifiedName: 'entry',
 		},
 
 		{

--- a/packages/dita-example-sx-shells-general-task/src/configureSxModule.ts
+++ b/packages/dita-example-sx-shells-general-task/src/configureSxModule.ts
@@ -3,6 +3,6 @@ import t from 'fontoxml-localization/src/t';
 import type { SxModule } from 'fontoxml-modular-schema-experience/src/sxManager';
 import xq from 'fontoxml-selectors/src/xq';
 
-export default function configureSxModule(sxModule: SxModule) {
+export default function configureSxModule(sxModule: SxModule): void {
 	configureMarkupLabel(sxModule, xq`self::task`, t('general task'));
 }


### PR DESCRIPTION
Updated the linter configuration. Specifically `.eslintrc.js` and `package.json`.

Removed an obsolete `npm run` command called `lint-fix`. As an alternative, you can run `npm run lint -- --fix` as this passes the `--fix` argument to the original command in the `package.json`.

The additional commit on this branch fixes all known linter errors and warnings.

It's best to review this change per commit. The first being the upgrade and the second being the fix.

Don't forget to run `npm install` upon checkout.