### PR TITLE
DEV-19021 Ensure mathml-edit is used with the correct contextNodeId.

### DIFF
--- a/packages/dita-example-sx-modules-xsd-equation-domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-equation-domain/src/configureSxModule.ts
@@ -20,7 +20,6 @@ export default function configureSxModule(sxModule: SxModule): void {
 		xq`self::equation-block`,
 		t('equation'),
 		{
-			contextualOperations: [{ name: 'mathml-edit' }],
 			blockHeaderLeft: [createMarkupLabelWidget()],
 		}
 	);
@@ -82,10 +81,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 	configureAsInlineFrame(
 		sxModule,
 		xq`self::equation-inline`,
-		t('inline equation'),
-		{
-			contextualOperations: [{ name: 'mathml-edit' }],
-		}
+		t('inline equation')
 	);
 
 	// equation-number

--- a/packages/dita-example-sx-modules-xsd-mathml-domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-mathml-domain/src/configureSxModule.ts
@@ -31,12 +31,6 @@ export default function configureSxModule(sxModule: SxModule): void {
 		xq`self::mathml[fonto:in-inline-layout(.)]`,
 		t('mathematical expression')
 	);
-	// The edit operation should be on the container of the mathml element in inline layout
-	configureContextualOperations(
-		sxModule,
-		xq`self::mathml[fonto:in-inline-layout(.)]`,
-		[]
-	);
 
 	// mathmlref
 	//     The MathML reference (<mathmlref>) element is used to refer to a non-DITA XML document containing


### PR DESCRIPTION
mathml-edit should point to a mathml element, not a container with (1 or more) mathml elements in it, like an equation-block or -inline. Otherwise it will always edit the first mathml element in them, and not the element your actually right-clicking on.

So also no longer disable contextual operations on mathml elements that are in an inline layout context.