### PR TITLE
Dev 25980 title query curated text

### DIFF
--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-base-mod/src/configureSxModule.ts
@@ -22,7 +22,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the audience'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -38,7 +38,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the challenge'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -53,7 +53,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -67,7 +67,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the instruction'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -91,7 +91,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the intro'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -105,7 +105,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the next steps'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -139,7 +139,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'lcObjectivesStem',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -168,7 +168,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the prerequisites'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -183,7 +183,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the resources'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -197,7 +197,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the review'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -212,7 +212,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the summary'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning-plan-mod/src/configureSxModule.ts
@@ -62,7 +62,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the alternate identifier'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -76,7 +76,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the classroom environment'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -90,7 +90,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the clients name'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -105,7 +105,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the constraints'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -119,7 +119,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the delivery date'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -141,7 +141,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the download time'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -172,7 +172,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			],
 			defaultTextContainer: 'p',
 			emptyElementPlaceholderText: t('Type the file size limitations'),
-			titleQuery: xq`./title`,
+			titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 			blockHeaderLeft: [createMarkupLabelWidget()],
 			blockOutsideAfter: [createElementMenuButtonWidget()],
 		}
@@ -187,7 +187,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'lcGapItem',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -207,7 +207,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideBefore: [createLabelQueryWidget(xq`"\u25cf"`)],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
@@ -259,7 +259,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the graphic requirements'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -274,7 +274,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the handouts'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -289,7 +289,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'lcInterventionItem',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -314,7 +314,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			],
 			defaultTextContainer: 'title',
 			isIgnoredForNavigation: false,
-			titleQuery: xq`./title`,
+			titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 			blockHeaderLeft: [createMarkupLabelWidget()],
 			blockOutsideBefore: [createLabelQueryWidget(xq`"\u25cf"`)],
 			blockOutsideAfter: [createElementMenuButtonWidget()],
@@ -358,7 +358,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the LMS name'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -372,7 +372,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the modification date'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -418,7 +418,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -432,7 +432,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			{ name: ':contextual-delete-lcNoLMS' },
 		],
 		defaultTextContainer: 'p',
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -447,7 +447,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the on-the-job-training aspects'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -470,7 +470,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			],
 			defaultTextContainer: 'title',
 			isIgnoredForNavigation: false,
-			titleQuery: xq`./title`,
+			titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 			blockHeaderLeft: [createMarkupLabelWidget()],
 			blockOutsideAfter: [createElementMenuButtonWidget()],
 		}
@@ -508,7 +508,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -522,7 +522,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the plan description'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -553,7 +553,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			],
 			defaultTextContainer: 'p',
 			emptyElementPlaceholderText: t('Type the plan prerequisites'),
-			titleQuery: xq`./title`,
+			titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 			blockHeaderLeft: [createMarkupLabelWidget()],
 			blockOutsideAfter: [createElementMenuButtonWidget()],
 		}
@@ -580,7 +580,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the plan subject'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -594,7 +594,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the plan title'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -608,7 +608,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the players'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -637,7 +637,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -651,7 +651,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the resolution'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -665,7 +665,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the security'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -707,7 +707,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -743,7 +743,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -764,7 +764,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the viewers'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -778,7 +778,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the W3C requirements'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -795,7 +795,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'title',
 		isIgnoredForNavigation: false,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});

--- a/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-spec-learning-xsd-learning2domain/src/configureSxModule.ts
@@ -261,7 +261,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' },
 		],
-		titleQuery: xq`./lcInteractionLabel2`,
+		titleQuery: xq`if (./lcInteractionLabel2) then fonto:curated-text-in-node(./lcInteractionLabel2) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -305,7 +305,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' },
 		],
-		titleQuery: xq`./lcInteractionLabel2`,
+		titleQuery: xq`if (./lcInteractionLabel2) then fonto:curated-text-in-node(./lcInteractionLabel2) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -405,7 +405,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 				{ name: ':contextual-move-down' },
 				{ name: ':contextual-delete-question' },
 			],
-			titleQuery: xq`./lcInteractionLabel2`,
+			titleQuery: xq`if (./lcInteractionLabel2) then fonto:curated-text-in-node(./lcInteractionLabel2) else ()`,
 			blockHeaderLeft: [createMarkupLabelWidget()],
 			blockOutsideAfter: [createElementMenuButtonWidget()],
 		}
@@ -423,7 +423,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 	//     Use <lcOpenQuestion2> to pose an open-ended question in an assessment interaction.
 	configureAsFrame(sxModule, xq`self::lcOpenQuestion2`, t('open question'), {
 		contextualOperations: [{ name: ':contextual-delete-question' }],
-		titleQuery: xq`./lcInteractionLabel2`,
+		titleQuery: xq`if (./lcInteractionLabel2) then fonto:curated-text-in-node(./lcInteractionLabel2) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -524,7 +524,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 				{ name: ':contextual-move-down' },
 				{ name: ':contextual-delete-question' },
 			],
-			titleQuery: xq`./lcInteractionLabel2`,
+			titleQuery: xq`if (./lcInteractionLabel2) then fonto:curated-text-in-node(./lcInteractionLabel2) else ()`,
 			blockHeaderLeft: [createMarkupLabelWidget()],
 			blockOutsideAfter: [createElementMenuButtonWidget()],
 		}
@@ -538,7 +538,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' },
 		],
-		titleQuery: xq`./lcInteractionLabel2`,
+		titleQuery: xq`if (./lcInteractionLabel2) then fonto:curated-text-in-node(./lcInteractionLabel2) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -552,7 +552,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			{ name: ':contextual-move-down' },
 			{ name: ':contextual-delete-question' },
 		],
-		titleQuery: xq`./lcInteractionLabel2`,
+		titleQuery: xq`if (./lcInteractionLabel2) then fonto:curated-text-in-node(./lcInteractionLabel2) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});

--- a/packages/dita-example-sx-modules-xsd-bookmap-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-bookmap-mod/src/configureSxModule.ts
@@ -184,7 +184,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			contextualOperations: formatContextualOperationListWithGroups(
 				getPlaceholderOrContainerOperations('placeholder')
 			),
-			titleQuery: 'upper-case(bookmap:retrieve-element-label(name()))',
+			titleQuery: xq`upper-case(bookmap:retrieve-element-label(name()))`,
 			blockHeaderLeft: [createMarkupLabelWidget()],
 		}
 	);
@@ -676,9 +676,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 				},
 			],
 			defaultTextContainer: 'title',
-			titleQuery: xq`
-			let $title := if(./title) then ./title else ./booktitle/mainbooktitle
-			return $title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+			titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else if (./booktitle/mainbooktitle) then fonto:curated-text-in-node(./booktitle/mainbooktitle) else ()`,
 			visibleChildSelector: xq`self::title or self::booktitle`,
 			blockFooter: [
 				createRelatedNodesQueryWidget(

--- a/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-common-element-mod/src/configureSxModule.ts
@@ -242,7 +242,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			},
 		},
 		isContextMenuScopeBoundary: true,
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});

--- a/packages/dita-example-sx-modules-xsd-equation-domain/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-equation-domain/src/configureSxModule.ts
@@ -72,7 +72,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 					],
 				},
 			},
-			titleQuery: xq`./title`,
+			titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 			blockHeaderLeft: [createMarkupLabelWidget()],
 			blockOutsideAfter: [createElementMenuButtonWidget()],
 		}

--- a/packages/dita-example-sx-modules-xsd-glossentry-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-glossentry-mod/src/configureSxModule.ts
@@ -89,7 +89,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 	//     terms in <term> elements and display the definition on hover or click. Glossary entries for
 	//     different term senses can be reused independently of one another. Category: Glossentry elements
 	configureAsSheetFrame(sxModule, xq`self::glossentry`, t('entry'), {
-		titleQuery: xq`./glossterm//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+		titleQuery: xq`fonto:curated-text-in-node(./glossterm)`,
 		blockFooter: [
 			createRelatedNodesQueryWidget(xq`./related-links`),
 			createRelatedNodesQueryWidget(

--- a/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.ts
@@ -32,7 +32,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 	// topichead
 	//     The <topichead> element provides a title-only entry in a navigation map, as an alternative to the
 	//     fully-linked title provided by the <topicref> element. Category: Mapgroup elements
-	configureAsSheetFrame(sxModule, xq`self::topichead`, t('topic group'), {
+	configureAsSheetFrame(sxModule, xq`self::topichead`, t('topic head'), {
 		titleQuery: xq`if (./topicmeta/navtitle) then fonto:curated-text-in-node(./topicmeta/navtitle) else string(./@navtitle)`,
 		visibleChildSelector: xq`self::topicmeta`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
@@ -60,14 +60,26 @@ export default function configureSxModule(sxModule: SxModule): void {
 	//     hierarchy, as opposed to nested < topicref> elements within a <topicref>, which does imply a
 	//     structural hierarchy. It is typically used outside a hierarchy to identify groups for linking
 	//     without affecting the resulting toc/navigation output. Category: Mapgroup elements
-	configureAsSheetFrame(
+	configureAsSheetFrame(sxModule, xq`self::topicgroup`, t('topic group'), {
 		titleQuery: xq`if (./topicmeta/navtitle) then fonto:curated-text-in-node(./topicmeta/navtitle) else string(./@navtitle)`,
+		visibleChildSelector: xq`self::topicmeta`,
+		blockHeaderLeft: [createMarkupLabelWidget()],
+	});
+
+	// topicmeta in topicgroup
+	configureAsStructure(
 		sxModule,
-		xq`self::topicgroup`,
-		t('untitled topic group'),
+		xq`self::topicmeta[parent::topicgroup]`,
+		undefined
+	);
+
+	// navtitle in topicmeta in topicgroup
+	configureAsTitleFrame(
+		sxModule,
+		xq`self::navtitle and parent::topicmeta[parent::topicgroup]`,
+		undefined,
 		{
-			visibleChildSelector: xq`self::topicmeta`,
-			blockHeaderLeft: [createMarkupLabelWidget()],
+			fontVariation: 'document-title',
 		}
 	);
 

--- a/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-map-group-mod/src/configureSxModule.ts
@@ -33,7 +33,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 	//     The <topichead> element provides a title-only entry in a navigation map, as an alternative to the
 	//     fully-linked title provided by the <topicref> element. Category: Mapgroup elements
 	configureAsSheetFrame(sxModule, xq`self::topichead`, t('topic group'), {
-		titleQuery: xq`if (topicmeta/navtitle) then (topicmeta/navtitle//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()) else string(./@navtitle)`,
+		titleQuery: xq`if (./topicmeta/navtitle) then fonto:curated-text-in-node(./topicmeta/navtitle) else string(./@navtitle)`,
 		visibleChildSelector: xq`self::topicmeta`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 	});
@@ -61,6 +61,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 	//     structural hierarchy. It is typically used outside a hierarchy to identify groups for linking
 	//     without affecting the resulting toc/navigation output. Category: Mapgroup elements
 	configureAsSheetFrame(
+		titleQuery: xq`if (./topicmeta/navtitle) then fonto:curated-text-in-node(./topicmeta/navtitle) else string(./@navtitle)`,
 		sxModule,
 		xq`self::topicgroup`,
 		t('untitled topic group'),

--- a/packages/dita-example-sx-modules-xsd-map-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-map-mod/src/configureSxModule.ts
@@ -62,34 +62,19 @@ export default function configureSxModule(sxModule: SxModule): void {
 	//     <topicref> can be used to override the short description in the topic. Category: Topic elements
 	configureAsRemoved(sxModule, xq`self::shortdesc`, t('introduction'));
 
+	// topicmeta
+	configureAsRemoved(sxModule, xq`self::topicmeta`, t('topic metadata'));
+
 	// topichead
 	//     The <topichead> element provides a title-only entry in a navigation map, as an alternative to the
 	//     fully-linked title provided by the <topicref> element. Category: Mapgroup elements
-	configureAsSheetFrame(sxModule, xq`self::topichead`, t('topic group'), {
+	configureAsSheetFrame(sxModule, xq`self::topichead`, t('topic head'), {
 		titleQuery: xq`if (./topicmeta/navtitle) then fonto:curated-text-in-node(./topicmeta/navtitle) else string(./@navtitle)`,
 		visibleChildSelector: xq`self::topicmeta`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 	});
 
-	// topicgroup
-	//     The <topicgroup> element is for creating groups of <topicref> elements without affecting the
-	//     hierarchy, as opposed to nested < topicref> elements within a <topicref>, which does imply a
-	//     structural hierarchy. It is typically used outside a hierarchy to identify groups for linking
-	//     without affecting the resulting toc/navigation output. Category: Mapgroup elements
-	configureAsSheetFrame(
-		sxModule,
-		xq`self::topicgroup`,
-		t('untitled topic group'),
-		{
-			titleQuery: xq`if (./topicmeta/navtitle) then fonto:curated-text-in-node(./topicmeta/navtitle) else string(./@navtitle)`,
-			visibleChildSelector: xq`self::topicmeta`,
-			blockHeaderLeft: [createMarkupLabelWidget()],
-		}
-	);
-
-	// topicmeta
-	configureAsRemoved(sxModule, xq`self::topicmeta`, t('topic metadata'));
-
+	// topicmeta in topichead
 	configureAsStructure(
 		sxModule,
 		xq`self::topicmeta[parent::topichead]`,
@@ -100,6 +85,34 @@ export default function configureSxModule(sxModule: SxModule): void {
 	configureAsTitleFrame(
 		sxModule,
 		xq`self::navtitle and parent::topicmeta[parent::topichead]`,
+		undefined,
+		{
+			fontVariation: 'document-title',
+		}
+	);
+
+	// topicgroup
+	//     The <topicgroup> element is for creating groups of <topicref> elements without affecting the
+	//     hierarchy, as opposed to nested < topicref> elements within a <topicref>, which does imply a
+	//     structural hierarchy. It is typically used outside a hierarchy to identify groups for linking
+	//     without affecting the resulting toc/navigation output. Category: Mapgroup elements
+	configureAsSheetFrame(sxModule, xq`self::topicgroup`, t('topic group'), {
+		titleQuery: xq`if (./topicmeta/navtitle) then fonto:curated-text-in-node(./topicmeta/navtitle) else string(./@navtitle)`,
+		visibleChildSelector: xq`self::topicmeta`,
+		blockHeaderLeft: [createMarkupLabelWidget()],
+	});
+
+	// topicmeta in topicgroup
+	configureAsStructure(
+		sxModule,
+		xq`self::topicmeta[parent::topicgroup]`,
+		undefined
+	);
+
+	// navtitle in topicmeta in topicgroup
+	configureAsTitleFrame(
+		sxModule,
+		xq`self::navtitle and parent::topicmeta[parent::topicgroup]`,
 		undefined,
 		{
 			fontVariation: 'document-title',

--- a/packages/dita-example-sx-modules-xsd-map-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-map-mod/src/configureSxModule.ts
@@ -18,7 +18,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 	// map
 	configureAsSheetFrame(sxModule, xq`self::map`, t('map'), {
 		defaultTextContainer: 'title',
-		titleQuery: xq`title//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		visibleChildSelector: xq`self::title`,
 		blockFooter: [
 			createRelatedNodesQueryWidget(
@@ -66,7 +66,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 	//     The <topichead> element provides a title-only entry in a navigation map, as an alternative to the
 	//     fully-linked title provided by the <topicref> element. Category: Mapgroup elements
 	configureAsSheetFrame(sxModule, xq`self::topichead`, t('topic group'), {
-		titleQuery: xq`if (topicmeta/navtitle) then (topicmeta/navtitle//text()[not(ancestor::*[name() = ("sort-at", "draft-comment", "foreign", "unknown", "required-cleanup", "image")])]/string() => string-join()) else string(./@navtitle)`,
+		titleQuery: xq`if (./topicmeta/navtitle) then fonto:curated-text-in-node(./topicmeta/navtitle) else string(./@navtitle)`,
 		visibleChildSelector: xq`self::topicmeta`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 	});
@@ -81,6 +81,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		xq`self::topicgroup`,
 		t('untitled topic group'),
 		{
+			titleQuery: xq`if (./topicmeta/navtitle) then fonto:curated-text-in-node(./topicmeta/navtitle) else string(./@navtitle)`,
 			visibleChildSelector: xq`self::topicmeta`,
 			blockHeaderLeft: [createMarkupLabelWidget()],
 		}

--- a/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-reference-mod/src/configureSxModule.ts
@@ -317,7 +317,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the syntax'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});

--- a/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-task-mod/src/configureSxModule.ts
@@ -266,7 +266,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			{ name: ':contextual-delete-step' },
 		],
 		defaultTextContainer: 'cmd',
-		titleQuery: xq`./cmd`,
+		titleQuery: xq`fonto:curated-text-in-node(./cmd)`,
 		blockBefore: [
 			createNumberingWidget(xq`self::step`, {
 				containerSelector: xq`self::steps`,
@@ -283,7 +283,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		t('step'),
 		{
 			defaultTextContainer: 'cmd',
-			titleQuery: xq`./cmd`,
+			titleQuery: xq`fonto:curated-text-in-node(./cmd)`,
 			blockBefore: [createLabelWidget('step')],
 			blockBeforeWidth: 'wide',
 		}
@@ -450,7 +450,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			{ name: ':contextual-delete-substep' },
 		],
 		defaultTextContainer: 'cmd',
-		titleQuery: xq`./cmd`,
+		titleQuery: xq`fonto:curated-text-in-node(./cmd)`,
 		blockBefore: [
 			createNumberingWidget(xq`self::substep`, {
 				numberingStyle: 'lowerAlpha',
@@ -468,7 +468,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		t('substep'),
 		{
 			defaultTextContainer: 'cmd',
-			titleQuery: xq`./cmd`,
+			titleQuery: xq`fonto:curated-text-in-node(./cmd)`,
 			blockBefore: [createLabelWidget('step')],
 			blockBeforeWidth: 'wide',
 		}

--- a/packages/dita-example-sx-modules-xsd-tbl-decl-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-tbl-decl-mod/src/configureSxModule.ts
@@ -53,7 +53,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 			{ name: ':cals-table-insert-desc' },
 		],
 		markupLabel: t('table figure'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});

--- a/packages/dita-example-sx-modules-xsd-topic-mod/src/configureSxModule.ts
+++ b/packages/dita-example-sx-modules-xsd-topic-mod/src/configureSxModule.ts
@@ -65,7 +65,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the content'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -244,7 +244,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		],
 		defaultTextContainer: 'p',
 		emptyElementPlaceholderText: t('Type the content'),
-		titleQuery: xq`./title`,
+		titleQuery: xq`if (./title) then fonto:curated-text-in-node(./title[1]) else ()`,
 		blockHeaderLeft: [createMarkupLabelWidget()],
 		blockOutsideAfter: [createElementMenuButtonWidget()],
 	});
@@ -332,7 +332,7 @@ export default function configureSxModule(sxModule: SxModule): void {
 		{
 			titleQuery: xq`
 					let $refNodeName := fonto:hierarchy-source-node(fonto:current-hierarchy-node-id())/name(),
-						$title := fonto:curated-text-in-node(./*[fonto:dita-class(., "topic/title")])
+						$title := fonto:curated-text-in-node(./*[fonto:dita-class(., "topic/title")][1])
 
 					return
 						if(not($refNodeName) or not(bookmap:retrieve-element-label($refNodeName)))


### PR DESCRIPTION
Use `fonto:curated-text-in-node()` for `titleQuery`, using conditionality and multiplicity based on the schema.

Additionally backported some `topichead` / `topicgroup` changes.